### PR TITLE
add correct DESTDIR to fhs.make (needed for rpmbuild)

### DIFF
--- a/SOPE/NGCards/versitCardsSaxDriver/fhs.make
+++ b/SOPE/NGCards/versitCardsSaxDriver/fhs.make
@@ -9,7 +9,7 @@ FHS_LIB_DIR=$(FHS_INSTALL_ROOT)/lib64/
 else
 FHS_LIB_DIR=$(FHS_INSTALL_ROOT)/lib/
 endif
-FHS_SAX_DIR=$(FHS_LIB_DIR)sope-$(MAJOR_VERSION).$(MINOR_VERSION)/saxdrivers/
+FHS_SAX_DIR=$(DESTDIR)/$(FHS_LIB_DIR)sope-$(MAJOR_VERSION).$(MINOR_VERSION)/saxdrivers/
 
 fhs-sax-dirs ::
 	$(MKDIRS) $(FHS_SAX_DIR)

--- a/SoObjects/SOGo/GNUmakefile.preamble
+++ b/SoObjects/SOGo/GNUmakefile.preamble
@@ -6,15 +6,15 @@ HOSTNAME ?= $(shell hostname -f)
 BUILD_DATE = $(shell echo $$USER@$(HOSTNAME); date +"%Y%m%d%H%M")
 
 ADDITIONAL_CPPFLAGS += \
-        -DSOGO_BUILD_DATE="@\"$(BUILD_DATE)\"" \
-        -DSOGO_LIBDIR="\"$(SOGO_LIBDIR)\"" \
-        -DSOGO_MAJOR_VERSION="@\"$(MAJOR_VERSION)\"" \
-        -DSOGO_MINOR_VERSION="@\"$(MINOR_VERSION)\"" \
-        -DSOGO_SUBMINOR_VERSION="@\"$(SUBMINOR_VERSION)\""
+	-DSOGO_BUILD_DATE="@\"$(BUILD_DATE)\"" \
+	-DSOGO_LIBDIR="\"$(SOGO_LIBDIR)\"" \
+	-DSOGO_MAJOR_VERSION="@\"$(MAJOR_VERSION)\"" \
+	-DSOGO_MINOR_VERSION="@\"$(MINOR_VERSION)\"" \
+	-DSOGO_SUBMINOR_VERSION="@\"$(SUBMINOR_VERSION)\""
 
 
 SOGo_LIBRARIES_DEPEND_UPON += \
-        -Wl,--no-as-needed \
+	-Wl,--no-as-needed	\
 	-L../../OGoContentStore/$(GNUSTEP_OBJ_DIR)/ -lOGoContentStore \
 	-L../../SOPE/NGCards/$(GNUSTEP_OBJ_DIR)/ \
 	-lmemcached		\
@@ -23,10 +23,10 @@ SOGo_LIBRARIES_DEPEND_UPON += \
 	-lNGCards		\
 	-lNGMime		\
 	-lNGStreams -lNGExtensions -lEOControl \
-	-lDOM -lSaxObjC \
-	-lNGLdap -lSBJson \
-        -lGDLContentStore \
-        $(BASE_LIBS)
+	-lDOM -lSaxObjC		\
+	-lNGLdap -lSBJson	\
+	-lGDLContentStore	\
+	$(BASE_LIBS)
 
 ifeq ($(HAS_LIBRARY_gnutls),yes)
 ADDITIONAL_CPPFLAGS += -DHAVE_GNUTLS=1
@@ -50,10 +50,10 @@ SOGo_LIBRARIES_DEPEND_UPON += -lcrypt
 endif
 
 ADDITIONAL_TOOL_LIBS += \
-        -L$(GNUSTEP_OBJ_DIR)/ \
-        -lSOGo \
+	-L$(GNUSTEP_OBJ_DIR)/		\
+	-lSOGo				\
 	-lGDLContentStore -lGDLAccess	\
-        -lNGCards                       \
+	-lNGCards			\
 	-lNGLdap			\
 	-lNGExtensions -lEOControl	\
 	-lDOM -lSaxObjC


### PR DESCRIPTION
I needed to add this patch to make rpmbuilds possible. And I want to get rid of this patch while having it upstream.
Kind Regards
Chris
