### PR TITLE
lookupLoginByDN complies to filters

### DIFF
--- a/SoObjects/SOGo/LDAPSource.m
+++ b/SoObjects/SOGo/LDAPSource.m
@@ -1223,13 +1223,19 @@ static Class NSStringK;
 {
   NGLdapConnection *ldapConnection;
   NGLdapEntry *entry;
+  NSEnumerator *e;
   NSString *login;
+  EOQualifier *qualifier;
   
   login = nil;
 
   ldapConnection = [self _ldapConnection];
-  entry = [ldapConnection entryAtDN: theDN
-                         attributes: [NSArray arrayWithObject: UIDField]];
+  qualifier = [self _qualifierForFilter: @"."];
+  e = [ldapConnection baseSearchAtBaseDN: theDN
+        qualifier: qualifier
+      attributes: [NSArray arrayWithObject: UIDField]];
+  entry = [e nextObject]; //just always use the base object, is the DN of the entry
+
   if (entry)
     login = [[entry attributeWithName: UIDField] stringValueAtIndex: 0];
 


### PR DESCRIPTION
Use provided LDAP search method to get login from dn. This way the configured filters are applied for each source, so we know which configured source this ldap entry comes from and which other configuration entries apply (like UIDFieldName).
