### PR TITLE
Fix #1158: Allow mail addresses with different full names

### DIFF
--- a/UI/MailerUI/UIxMailEditor.m
+++ b/UI/MailerUI/UIxMailEditor.m
@@ -53,6 +53,7 @@
 #import <SOGo/SOGoUserFolder.h>
 #import <SOGo/NSArray+Utilities.h>
 #import <SOGo/NSDictionary+Utilities.h>
+#import <SOGo/NSString+Utilities.h>
 #import <SOGo/WOResourceManager+SOGo.h>
 #import <SOGoUI/UIxComponent.h>
 #import <Mailer/SOGoDraftObject.h>
@@ -239,15 +240,27 @@ static NSArray *infoKeys = nil;
 
 - (NSString *) _emailFromIdentity: (NSDictionary *) identity
 {
-  NSString *fullName, *format;
+  NSString *email;
+  NSRange delimiter;
 
-  fullName = [identity objectForKey: @"fullName"];
-  if ([fullName length])
-    format = @"%{fullName} <%{email}>";
+  email     = [identity objectForKey: @"email"];
+
+  delimiter = [email rangeOfString: @"<"];
+  // 'bro@example.com' => '"Bro" <bro@example.com>'  (fullName = "Bro")
+  // 'bro@example.com' => 'bro@example.com'          (fullName = "")
+  if (delimiter.location == NSNotFound)
+    {
+      if ([[identity objectForKey: @"fullName"] length])
+        return [identity keysWithFormat: @"%{fullName} <%{email}>"];
+      else
+        return email;
+    }
+  // '<bro@example.com>' => 'bro@example.com' (fullName = "Bro" or "")
+  else if (delimiter.location == 0)
+    return [email pureEMailAddress];
+  // '"Dude" <bro@example.com>' => '"Dude" <bro@example.com>' (fullName = "Bro" or "")
   else
-    format = @"%{email}";
-
-  return [identity keysWithFormat: format];
+    return email;
 }
 
 - (NSString *) from

--- a/UI/WebServerResources/UIxPreferences.js
+++ b/UI/WebServerResources/UIxPreferences.js
@@ -729,7 +729,14 @@ function displayMailAccount(mailAccount, readOnly) {
                     ? mailAccount["identities"][0]
                     : {} );
     $("fullName").value = identity["fullName"] || "";
-    $("email").value = identity["email"] || "";
+    if(identity["email"]) {
+        var pureEMailRE = new RegExp("(.*<|^)([^>]*)");
+        var match = pureEMailRE.exec(identity["email"]);
+        $("email").value = match[2];
+    }
+    else {
+        $("email").value = "";
+    }
     $("replyTo").value = identity["replyTo"] || "";
 
     displayAccountSignature(mailAccount);


### PR DESCRIPTION
As stated in http://www.sogo.nu/bugs/view.php?id=1158, the the MailFieldNames fields (like _mail_) can only contain a plain E-Mail address, without a full name like _"Dude" <bro@example.com>_. If the value contains never the less a full value, something strange happened:
- Since SOGo 2.2.1: The result would have been _"Bro" <"Dude" <bro@example.com>>_
- Before SOGo 2.2.1: The result would have been _"Bro" <bro@example.com>_
  therefore the only sane values have been without a full name and "<>".

Now it is possible to have
- E-Mail addresses without a full name
- E-Mail addresses with a different full name

to accomplish this, without breaking backward compatibility for former sane configurations, the new behavior only kicks in if the value contains a "<". Depending on it's position, one of the two new E-Mails address types is selected. The mapping is as following:

| Input | Result | Users fullName |
| --: | --: | :-: |
| bro@example.com | "Bro" <bro@example.com> | "Bro" |
| bro@example.com | bro@example.com | "" |
| <bro@example.com> | bro@example.com | "Bro" or "" |
| "Dude" <bro@example.com> | "Dude" <bro@example.com> | "Bro" or "" |
