### PR TITLE
Remove build date from binary

### DIFF
--- a/Main/SOGo.m
+++ b/Main/SOGo.m
@@ -107,8 +107,8 @@ static BOOL debugLeaks;
   SoClassSecurityInfo *sInfo;
   NSArray *basicRoles;
 
-  [self logWithFormat: @"version %@ (build %@) -- starting",
-        SOGoVersion, SOGoBuildDate];
+  [self logWithFormat: @"version %@ -- starting",
+        SOGoVersion];
 
   defaults = [SOGoSystemDefaults sharedSystemDefaults];
   doCrashOnSessionCreate = [defaults crashOnSessionCreate];

--- a/SoObjects/SOGo/GNUmakefile
+++ b/SoObjects/SOGo/GNUmakefile
@@ -81,10 +81,6 @@ SOGo_HEADER_FILES = \
 	\
 	SOGoCredentialsFile.h
 
-# daemon tool
-all::
-	@touch SOGoBuild.m
-
 SOGo_OBJC_FILES = \
 	SOGoBuild.m \
 	SOGoProductLoader.m		\

--- a/SoObjects/SOGo/SOGoBuild.h
+++ b/SoObjects/SOGo/SOGoBuild.h
@@ -23,7 +23,6 @@
 #ifndef BUILD_H
 #define BUILD_H
 
-extern NSString *SOGoBuildDate;
 extern NSString *SOGoVersion;
 
 #endif /* BUILD_H */

--- a/SoObjects/SOGo/SOGoBuild.m
+++ b/SoObjects/SOGo/SOGoBuild.m
@@ -22,7 +22,6 @@
 
 #import <Foundation/NSString.h>
 
-NSString *SOGoBuildDate = SOGO_BUILD_DATE;
 NSString *SOGoVersion = (SOGO_MAJOR_VERSION
                          @"." SOGO_MINOR_VERSION
                          @"." SOGO_SUBMINOR_VERSION);

--- a/UI/SOGoUI/UIxComponent.h
+++ b/UI/SOGoUI/UIxComponent.h
@@ -116,7 +116,6 @@
 - (WOResponse *) redirectToLocation: (NSString *) newLocation;
 
 /* Debugging */
-- (NSString *) buildDate;
 - (BOOL) isUIxDebugEnabled;
 
 @end

--- a/UI/SOGoUI/UIxComponent.m
+++ b/UI/SOGoUI/UIxComponent.m
@@ -719,11 +719,6 @@ static SoProduct      *commonProduct      = nil;
 
 /* debugging */
 
-- (NSString *) buildDate
-{
-  return SOGoBuildDate;
-}
-
 - (BOOL) isUIxDebugEnabled
 {
   SOGoSystemDefaults *sd;

--- a/UI/Templates/MainUI/SOGoRootPage.wox
+++ b/UI/Templates/MainUI/SOGoRootPage.wox
@@ -13,7 +13,7 @@
   <div id="aboutBox" style="display:none;">
     <div>
       <p class="logo"><img const:alt="SOGo" rsrc:src="sogo-logo.png"/></p>
-      <p>Version <var:string value="version"/> <span class="buildDate">(<var:string value="buildDate" />)</span></p>
+      <p>Version <var:string value="version"/></p>
       <p class="scroll"><var:string label:value="AboutBox" const:escapeHTML="NO"/></p>
       <img const:alt="Inverse" rsrc:src="inverse.png"/>
       <p class="links"><a href="http://www.sogo.nu/" target="_new">www.sogo.nu</a> / 

--- a/UI/Templates/UIxPageFrame.wox
+++ b/UI/Templates/UIxPageFrame.wox
@@ -19,7 +19,6 @@
         <meta name="description" content="SOGo Web Interface" />
         <meta name="author" content="SKYRIX Software AG/Inverse inc." />
         <meta name="robots" content="stop" />
-        <meta name="build" var:content="buildDate" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
         <link href="mailto:support@inverse.ca" rev="made" />
         <link rel="shortcut icon" var:href="siteFavicon" type="image/x-icon" />

--- a/UI/WebServerResources/SOGoRootPage.css
+++ b/UI/WebServerResources/SOGoRootPage.css
@@ -26,9 +26,6 @@ DIV#aboutBox DIV
   padding-bottom: 20px;
   width: 550px; }
 
-DIV#aboutBox SPAN.buildDate
-{ color: #666; }
-
 A#aboutClose
 { position: relative;
   margin-right: 10px;


### PR DESCRIPTION
There are two reasons for this patch. The first is that "touch SOGoBuild.m" is run during "make install", causing a recompile of the file and a relink of the library that includes it. But when building packages DESTDIR is set to some temporary directory with "make install", which means SOGO_SYSLIBDIR is set to the temporary directory and the RPATH in the library will be wrong.

The second reason is that we are working on making package builds reproducible in Debian, see https://wiki.debian.org/ReproducibleBuilds for more information. Putting the build time in the binary causes differences between builds. Given that the version number is already there I don't think the build date adds a lot more useful information. If you insist on keeping a date in the binary another solution would be to make it possible to set the build date using an environment variable, then the Debian build script could set it to the debian changelog date and it would also be reproducible.
