### PR TITLE
Allow rpmbuild as non-root user

### DIFF
--- a/packaging/rhel/sogo.spec
+++ b/packaging/rhel/sogo.spec
@@ -243,8 +243,8 @@ install -d ${RPM_BUILD_ROOT}/var/lib/sogo
 install -d ${RPM_BUILD_ROOT}/var/log/sogo
 install -d ${RPM_BUILD_ROOT}/var/run/sogo
 install -d ${RPM_BUILD_ROOT}/var/spool/sogo
-install -d -m 750 -o %sogo_user -g %sogo_user ${RPM_BUILD_ROOT}/etc/sogo
-install -m 640 -o %sogo_user -g %sogo_user Scripts/sogo.conf ${RPM_BUILD_ROOT}/etc/sogo/
+install -d -m 750 ${RPM_BUILD_ROOT}/etc/sogo
+install -m 640 Scripts/sogo.conf ${RPM_BUILD_ROOT}/etc/sogo/
 #install -m 755 Scripts/openchange_user_cleanup ${RPM_BUILD_ROOT}/%{_sbindir}
 cat Apache/SOGo.conf | sed -e "s@/lib/@/%{_lib}/@g" > ${RPM_BUILD_ROOT}/etc/httpd/conf.d/SOGo.conf
 install -m 600 Scripts/sogo.cron ${RPM_BUILD_ROOT}/etc/cron.d/sogo


### PR DESCRIPTION
Installing with user and group permissions here requires root access which shouldn't be required for building an RPM. It also assumes a "sogo" user and group exists.

This change shouldn't affect the final file permissions after installing the RPM as the permissions are set in the %files section on line 332:

```
%config(noreplace) %attr(0640, root, %sogo_user) %{_sysconfdir}/sogo/sogo.conf
```
