### PR TITLE
fix(core/ldap): When creating a new contact, also write the "sn" field

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -797,6 +797,7 @@ SOGoUserSources = (
     {
         type = ldap;
         CNFieldName = cn;
+        SNFieldName = sn;
         IDFieldName = uid;
         UIDFieldName = uid;
         IMAPHostFieldName = mailHost;
@@ -840,6 +841,7 @@ SOGoUserSources = (
     {
         type = ldap;
         CNFieldName = cn;
+        SNFieldName = sn;
         IDFieldName = cn;
         UIDFieldName = sAMAccountName;
         baseDN = "cn=Users,dc=acme,dc=com";

--- a/Scripts/sogo.conf
+++ b/Scripts/sogo.conf
@@ -47,6 +47,7 @@
   //  {
   //    type = ldap;
   //    CNFieldName = cn;
+  //    SNFieldName = sn;
   //    UIDFieldName = uid;
   //    IDFieldName = uid; // first field of the DN for direct binds
   //    bindFields = (uid, mail); // array of fields to use for indirect binds
@@ -66,6 +67,7 @@
   //  {
   //    type = ldap;
   //    CNFieldName = cn;
+  //    SNFieldName = sn;
   //    UIDFieldName = sAMAccountName;
   //    baseDN = "CN=users,dc=domain,dc=tld";
   //    bindDN = "CN=sogo,CN=users,DC=domain,DC=tld";

--- a/SoObjects/SOGo/LDAPSource.h
+++ b/SoObjects/SOGo/LDAPSource.h
@@ -55,6 +55,7 @@
   LDAPSourceSchema *_schema;
   NSString *_IDField;     // the first part of a user DN
   NSString *_CNField;
+  NSString *_SNField;
   NSString *_UIDField;
   NSArray *_mailFields;
   NSArray *_searchFields;
@@ -102,6 +103,7 @@
 - (void) setBaseDN: (NSString *) newBaseDN
 	   IDField: (NSString *) newIDField
 	   CNField: (NSString *) newCNField
+       SNField: (NSString *) newSNField
 	  UIDField: (NSString *) newUIDField
 	mailFields: (NSArray *) newMailFields
       searchFields: (NSArray *) newSearchFields

--- a/SoObjects/SOGo/LDAPSource.m
+++ b/SoObjects/SOGo/LDAPSource.m
@@ -91,6 +91,7 @@ static Class NSStringK;
       _schema = nil;
       _IDField = @"cn"; /* the first part of a user DN */
       _CNField = @"cn";
+      _SNField = @"sn";
       _UIDField = @"uid";
       _mailFields = [[NSArray arrayWithObject: @"mail"] retain];
       _contactMapping = nil;
@@ -139,6 +140,7 @@ static Class NSStringK;
   [_pristineBaseDN release];
   [_IDField release];
   [_CNField release];
+  [_SNField release];
   [_UIDField release];
   [_contactMapping release];
   [_mailFields release];
@@ -187,6 +189,7 @@ static Class NSStringK;
       [self setBaseDN: [udSource objectForKey: @"baseDN"]
               IDField: [udSource objectForKey: @"IDFieldName"]
               CNField: [udSource objectForKey: @"CNFieldName"]
+              SNField: [udSource objectForKey: @"SNFieldName"]
              UIDField: [udSource objectForKey: @"UIDFieldName"]
            mailFields: [udSource objectForKey: @"MailFieldNames"]
          searchFields: [udSource objectForKey: @"SearchFieldNames"]
@@ -327,6 +330,7 @@ static Class NSStringK;
 - (void) setBaseDN: (NSString *) newBaseDN
            IDField: (NSString *) newIDField
            CNField: (NSString *) newCNField
+           SNField: (NSString *) newSNField
           UIDField: (NSString *) newUIDField
         mailFields: (NSArray *) newMailFields
       searchFields: (NSArray *) newSearchFields
@@ -345,6 +349,8 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
     ASSIGN(_IDField, [newIDField lowercaseString]);
   if (newCNField)
     ASSIGN(_CNField, [newCNField lowercaseString]);
+  if (newSNField)
+    ASSIGN(_SNField, [newSNField lowercaseString]);
   if (newUIDField)
     ASSIGN(_UIDField, [newUIDField lowercaseString]);
   if (newIMAPHostField)
@@ -1216,6 +1222,11 @@ groupObjectClasses: (NSArray *) newGroupObjectClasses
   if (!value)
     value = @"";
   [ldifRecord setObject: value forKey: @"c_cn"];
+
+  value = [[ldapEntry attributeWithName: _SNField] stringValueAtIndex: 0];
+  if (!value)
+    value = @"";
+  [ldifRecord setObject: value forKey: @"c_sn"];
   /* if "displayName" is not set, we use CNField because it must exist */
   if (![ldifRecord objectForKey: @"displayname"])
     [ldifRecord setObject: value forKey: @"displayname"];
@@ -1819,6 +1830,7 @@ _makeLDAPChanges (NGLdapConnection *ldapConnection,
               [ab setBaseDN: [entry dn]
 		    IDField: @"cn"
 		    CNField: @"displayName"
+		    SNField: @"sn"
 		   UIDField: @"cn"
 		 mailFields: nil
 		  searchFields: nil


### PR DESCRIPTION
The "sn" attribute is mandatory for "inetOrgPerson" object class, so it
should be written otherwise entries cannot be added and fails for example
with

     Entry (cn=73a6-59920600-5-56454280,ou=personal,ou=addressbook,uid=alise,ou=peoples,dc=domain,dc=tld): object class 'inetOrgPerson' requires attribute 'sn'

Fixes [#4206](https://sogo.nu/bugs/view.php?id=4206)
Fixes [#4248](https://sogo.nu/bugs/view.php?id=4248)


Note this is *not tested*