### PR TITLE
Fix OOM when having a lot of recurrence rules

### DIFF
--- a/SoObjects/Appointments/SOGoAppointmentFolder.m
+++ b/SoObjects/Appointments/SOGoAppointmentFolder.m
@@ -1358,7 +1358,9 @@ firstInstanceCalendarDateRange: (NGCalendarDateRange *) fir
               rules = [component recurrenceRulesWithTimeZone: tz];
               exRules = [component exceptionRulesWithTimeZone: tz];
             }
-          
+
+          rules = [rules uniqueObjects];
+
           // Calculate the occurrences for the given range
           records = [NSMutableArray array];
           ranges =


### PR DESCRIPTION
We had a broken client that created calendar entries with a lot of recurrence rule (all of them FREQ=WEEKLY) and a lot of alarms. This led to SOGo going out of memory.

This patch works around that by filtering out duplicated rules as they yield the same date ranges and we only need to have them once.