### PR TITLE
fix(eas) ensure Templates and Junk folder exits (fixes #5626)

### DIFF
--- a/ActiveSync/SOGoActiveSyncDispatcher.m
+++ b/ActiveSync/SOGoActiveSyncDispatcher.m
@@ -877,6 +877,8 @@ void handle_eas_terminate(int signum)
       [self _ensureFolder: (SOGoMailFolder *)[accountFolder draftsFolderInContext: context]];
       [self _ensureFolder: [accountFolder sentFolderInContext: context]];
       [self _ensureFolder: (SOGoMailFolder *)[accountFolder trashFolderInContext: context]];
+      [self _ensureFolder: (SOGoMailFolder *)[accountFolder junkFolderInContext: context]];
+      [self _ensureFolder: (SOGoMailFolder *)[accountFolder templatesFolderInContext: context]];
     }
 
   allFoldersMetadata = [NSMutableArray array];


### PR DESCRIPTION
The fix ensures that Templates and Junk folder exists when creating an EAS account.