### PR TITLE
Adjust imap authenticate documentation

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -2092,7 +2092,10 @@ The default value is `YES`.
 
 |S |NGImap4AuthMechanism
 |Trigger the use of the IMAP `AUTHENTICATE` command with the specified
-SASL mechanism. Please note that feature might be limited at this time.
+SASL mechanism. Using `AUTHENTICATE` instead of `LOGIN` is also necessary
+to enable UTF-8 characters in users' passwords. To enable simple use of
+`AUTHENTICATE` for this purpose, set this setting to `plain`. Please note 
+that this feature might be limited at this time.
 
 |D |NGImap4ConnectionGroupIdPrefix
 |Prefix to prepend to names in IMAP ACL transactions, to indicate the

--- a/Scripts/sogo.conf
+++ b/Scripts/sogo.conf
@@ -32,6 +32,7 @@
   //SOGoMailingMechanism = smtp;
   //SOGoForceExternalLoginWithEmail = NO;
   //SOGoMailSpoolPath = /var/spool/sogo;
+  //NGImap4AuthMechanism = "plain";
   //NGImap4ConnectionStringSeparator = "/";
 
   /* Notifications */


### PR DESCRIPTION
This pull-request updates the default configuration file and the documentation to highlight that `NGImap4AuthMechanism = "plain";` should be set to force `AUTHENTICATE` usage if users' passwords may contain UTF-8 characters like umlauts.

Otherwise, users may update their passwords via SOGo to ones containing an UTF-8 character, which then inadvertedly breaks the mail view, as logging in via `LOGIN` is no longer possible. Logging into SOGo itself still works, but users are presented with a white page when trying to access the mail view.

***Security Side Note:*** Depending on the setup it seems to be possible to lock up SOGo worker threads using this, ultimately leading to a DoS (as soon as all workers are busy for this user). Specifically, I just had one user on a small (20 worker threads) instance setting a password containing an umlaut. As the user tried to log in multiple times, ultimately all workers were busy with trying to authenticate to the IMAP server. I did not fully debug this, but there might also be some malicious potential in this for some malicious activity.