### PR TITLE
fix(calendar(js)): prevent duplicate event creation in case of an event conflict

### DIFF
--- a/UI/Templates/SchedulerUI/UIxAppointmentEditorTemplate.wox
+++ b/UI/Templates/SchedulerUI/UIxAppointmentEditorTemplate.wox
@@ -7,7 +7,7 @@
   <md-dialog 
   flex="{{ editor.isFullscreen?    100 : 60 }}"
   flex-sm="{{ editor.isFullscreen? 100 : 80 }}">
-    <form name="eventForm" class="md-inline-form" ng-submit="editor.save(eventForm)">
+    <form name="eventForm" class="md-inline-form">
       <md-toolbar>
         <div class="md-toolbar-tools sg-no-transition">
           <md-icon class="material-icons sg-icon-toolbar-bg">event</md-icon>
@@ -333,6 +333,7 @@
           <var:string label:value="Reset"/>
         </md-button>
         <md-button class="md-primary" type="submit"
+                   ng-click="editor.save(eventForm)"
                    ng-disabled="eventForm.$invalid || eventForm.$submitted">
           <var:string label:value="Save"/>
         </md-button>
@@ -374,9 +375,9 @@
                    ng-click="editor.edit(eventForm)">
           <var:string label:value="Edit"/>
         </md-button>
-        <md-button class="md-warn" type="button"
+        <md-button class="md-warn" type="submit"
                    ng-click="editor.save(eventForm, { ignoreConflicts: true })"
-                   ng-disabled="editor.eventForm.$invalid">
+                   ng-disabled="eventForm.$invalid || eventForm.$submitted">
           <var:string label:value="Save"/>
         </md-button>
       </md-dialog-actions>
@@ -409,10 +410,10 @@
                    ng-click="editor.edit(eventForm)">
           <var:string label:value="Edit"/>
         </md-button>
-        <md-button class="md-warn" type="button"
+        <md-button class="md-warn" type="submit"
                    ng-show="editor.attendeeConflictError.unavailableAttendees"
                    ng-click="editor.save(eventForm, { removeAttendees: editor.attendeeConflictError.unavailableAttendees })"
-                   ng-disabled="editor.eventForm.$invalid">
+                   ng-disabled="eventForm.$invalid || eventForm.$submitted">
           <var:string label:value="Save"/>
         </md-button>
       </md-dialog-actions>

--- a/UI/WebServerResources/js/Scheduler/ComponentController.js
+++ b/UI/WebServerResources/js/Scheduler/ComponentController.js
@@ -547,10 +547,13 @@
               $mdDialog.cancel = vm.originalModalCancel;
               $mdDialog.hide();
             }, function(response) {
-              if (response.status == CalendarSettings.ConflictHTTPErrorCode)
+              vm.allowResubmit(form);
+
+              if (response.status == CalendarSettings.ConflictHTTPErrorCode) {
                 vm.attendeeConflictError = _.isObject(response.data.message) ? response.data.message : { reject: response.data.message };
-              else
+              } else {
                 vm.edit(form);
+              }
             });
         }
       });
@@ -580,6 +583,11 @@
 
     this.edit = function (form) {
       this.attendeeConflictError = false;
+      form.$setPristine();
+      form.$setDirty();
+    };
+
+    this.allowResubmit = function (form) {
       form.$setPristine();
       form.$setDirty();
     };


### PR DESCRIPTION
In case of an calendar event conflict the form submit button was not disabled on use, allowing it to be clicked again.
This could have resulted in a double creation of the event.