### PR TITLE
i18n(de_DE): Update German translations

### DIFF
--- a/SoObjects/Appointments/German.lproj/Localizable.strings
+++ b/SoObjects/Appointments/German.lproj/Localizable.strings
@@ -35,7 +35,7 @@ vtodo_class2 = "(Vertrauliche Aufgabe)";
 /* Invitation */
 "Event Invitation: \"%{Summary}\"" = "Termineinladung: \"%{Summary}\"";
 "(sent by %{SentBy}) " = "(gesendet von %{SentBy}) ";
-"%{Organizer} %{SentByText}has invited you to %{Summary}.\n\nStart: %{StartDate}\nEnd: %{EndDate}\nDescription: %{Description}" = "%{Organizer} %{SentByText} Hat Sie eingeladen zu \"%{Summary}\".\n\nBeginn: %{StartDate}\nEnde: %{EndDate}\nBeschreibung: %{Description}";
+"%{Organizer} %{SentByText}has invited you to %{Summary}.\n\nStart: %{StartDate}\nEnd: %{EndDate}\nDescription: %{Description}" = "%{Organizer} %{SentByText} hat Sie eingeladen zu \"%{Summary}\".\n\nBeginn: %{StartDate}\nEnde: %{EndDate}\nBeschreibung: %{Description}";
 "%{Organizer} %{SentByText}has invited you to %{Summary}.\n\nStart: %{StartDate} at %{StartTime}\nEnd: %{EndDate} at %{EndTime}\nDescription: %{Description}" = "%{Organizer} %{SentByText} hat Sie eingeladen zu \"%{Summary}\".\n\nBeginn: %{StartDate} um %{StartTime}\nEnde: %{EndDate} um %{EndTime}\nBeschreibung: %{Description}";
 
 /* Deletion */
@@ -47,11 +47,11 @@ vtodo_class2 = "(Vertrauliche Aufgabe)";
 
 /* Update */
 "The appointment \"%{Summary}\" for the %{OldStartDate} has changed"
-= "Die Verabredung \"%{Summary}\" am %{OldStartDate} wurde geändert";
+= "Der Termin \"%{Summary}\" am %{OldStartDate} hat sich geändert";
 "The appointment \"%{Summary}\" for the %{OldStartDate} at %{OldStartTime} has changed"
 = "Der Termin \"%{Summary}\" am %{OldStartDate} um %{OldStartTime} hat sich geändert";
 "The following parameters have changed in the \"%{Summary}\" meeting:"
-= "Folgendes wurde am Termin \"%{Summary}\" geändert:";
+= "Folgendes hat sich am Termin \"%{Summary}\" geändert:";
 "Please accept or decline those changes."
 = "Bitte akzeptieren Sie diese Änderung oder lehnen Sie diese ab.";
 
@@ -65,7 +65,7 @@ vtodo_class2 = "(Vertrauliche Aufgabe)";
 "%{Attendee} %{SentByText}has declined your event invitation."
 = "%{Attendee} %{SentByText} hat Ihre Termineinladung abgelehnt.";
 "%{Attendee} %{SentByText}has delegated the invitation to %{Delegate}."
-= "%{Attendee} %{SentByText} hat die Einladung delegiert an %{Delegate}.";
+= "%{Attendee} %{SentByText} hat die Termineinladung delegiert an %{Delegate}.";
 "%{Attendee} %{SentByText}has not yet decided upon your event invitation."
 = "%{Attendee} %{SentByText} hat noch nicht über Ihre Termineinladung entschieden.";
 

--- a/UI/Scheduler/German.lproj/Localizable.strings
+++ b/UI/Scheduler/German.lproj/Localizable.strings
@@ -386,17 +386,17 @@
 "Reminder relation" = "Bezug der Erinnerung";
 
 /* transparency */
-"Show Time as Free" = "Zeige Zeit als Verfügbar";
+"Show Time as Free" = "Zeige Zeit als verfügbar";
 
 /* email notifications */
-"Send Appointment Notifications" = "Verabredungsbenachrichtigungen senden";
+"Send Appointment Notifications" = "Terminbenachrichtigungen senden";
 "From" = "Von";
 "To" = "Bis";
 
 /* validation errors */
-validate_notitle           = "Sie haben keinen Titel eingegeben. Wollen Sie trotzdem fortfahren?";
-validate_invalid_startdate = "Ungültiges Beginndatum !";
-validate_invalid_enddate   = "Ungültiges Enddatum !";
+validate_notitle           = "Sie haben keinen Titel eingegeben. Möchten Sie trotzdem fortfahren?";
+validate_invalid_startdate = "Ungültiges Beginndatum!";
+validate_invalid_enddate   = "Ungültiges Enddatum!";
 validate_endbeforestart    = "Ihr Ende ist vor dem Beginndatum.";
 validate_untilbeforeend    = "Die Wiederholung muss nach dem ersten Auftreten enden.";
 
@@ -438,9 +438,9 @@ validate_untilbeforeend    = "Die Wiederholung muss nach dem ersten Auftreten en
 "You cannot remove nor unsubscribe from your personal calendar."
 = "Der persönliche Kalender kann weder gelöscht noch abbestellt werden.";
 "Are you sure you want to delete the calendar \"%{0}\"?"
-= "Wollen Sie diesen Kalender wirklich löschen \"%{0}\"?";
+= "Möchten Sie diesen Kalender wirklich löschen \"%{0}\"?";
 "Are you sure you want to delete the selected components?"
-= "Wollen Sie wirklich die ausgewählten Komponenten löschen?";
+= "Möchten Sie die ausgewählten Komponenten wirklich löschen?";
 
 /* Participation role */
 "Role" = "Rolle";
@@ -498,7 +498,7 @@ validate_untilbeforeend    = "Die Wiederholung muss nach dem ersten Auftreten en
 "Between" = "Zwischen";
 "and" = "und";
 "A time conflict exists with one or more attendees.\nWould you like to keep the current settings anyway?"
-= "Dieser Termin überschneidet sich mit dem Termin mindestens eines Teilnehmers.\nWollen sie die Einstellungen trotzdem so belassen?";
+= "Dieser Termin überschneidet sich mit dem Termin mindestens eines Teilnehmers.\nMöchten Sie die Einstellungen trotzdem so belassen?";
 "Would you like to remove them and send the invitation to the remaining attendees?"
 = "Möchten Sie diese entfernen, und die Einladung an die verbleibenden Teilnehmer schicken?";
 
@@ -517,7 +517,7 @@ vtodo_class2 = "(Vertrauliche Aufgabe)";
 "closeThisWindowMessage" = "Vielen Dank! Sie können dieses Fenster jetzt schließen.";
 "Multicolumn Day View" = "Mehrspaltige Tagesansicht";
 "Please select an event or a task." = "Bitte wählen Sie einen Termin oder eine Aufgabe aus!";
-"editRepeatingItem" = "Sie bearbeiten einen sich wiederholenden Termin. Wollen Sie alle seine Ereignisse bearbeiten oder nur diese einzelne Instanz?";
+"editRepeatingItem" = "Sie bearbeiten einen sich wiederholenden Termin. Möchten Sie alle Ereignisse bearbeiten oder nur diese einzelne Instanz?";
 "button_thisOccurrenceOnly" = "Nur diese Instanz";
 "button_allOccurrences" = "Alle Ereignisse";
 "Edit This Occurrence" = "Diese Instanz ändern";


### PR DESCRIPTION
 1. "hat" is a verb and has to be lowercase in the middle of a sentence (like in the translation below).
 2. "Verabredung" is informal, "Termin" is formal; use it consistently (like in the translations below).
 3. The current German translation would better suit if it would have been "was changed" in English.
 4. Use the same word "Termineinladung" consistently (like in the translations above and below).
 5. "verfügbar" is an adjective and has to be lowercase in the middle of a German sentence (otherwise put e.g. into quotation marks).
 6. "Verabredung" is informal, "Termin" is formal; use it consistently (and "Verabredungsbenachrichtigungen" is a very strange word).
 7. "Möchten" is more polite, quite similar like "Would you like to continue?" rather than "Do you want to continue?".
 8. German punctuation requires punctuation marks directly after the last word without any whitespace (difference to e.g. French).
 9. When talking to somebody, "sie" (as in "you") needs to be "Sie" to be more polite (like in the other translations).
10. "alle seine Ereignisse" would translate to "all his occurences", in German it's IMHO usually "all occurences".