### PR TITLE
Fix moving mails across mailboxes

### DIFF
--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -785,6 +785,7 @@ static NSInteger _compareFetchResultsByUID (id entry1, id entry2, NSDictionary *
                   NSDictionary *message;
                   NSData *content;
                   NSArray *flags;
+                  NGImap4Client *dstClient;
 
                   // Fetch messages
                   result = [client fetchUids: uids parts: [NSArray arrayWithObjects: @"RFC822", @"FLAGS", nil]];
@@ -794,7 +795,7 @@ static NSInteger _compareFetchResultsByUID (id entry1, id entry2, NSDictionary *
                       if ([result isKindOfClass: [NSArray class]] && [result count] > 0)
                         {
                           // Copy each message to the other account
-                          NGImap4Client *dstClient = [[account imap4Connection] client];
+                          dstClient = [[account imap4Connection] client];
                           [[account imap4Connection] selectFolder: imapDestinationFolder];
                           messages = [result objectEnumerator];
                           result = nil;

--- a/SoObjects/Mailer/SOGoMailFolder.m
+++ b/SoObjects/Mailer/SOGoMailFolder.m
@@ -794,7 +794,7 @@ static NSInteger _compareFetchResultsByUID (id entry1, id entry2, NSDictionary *
                       if ([result isKindOfClass: [NSArray class]] && [result count] > 0)
                         {
                           // Copy each message to the other account
-                          client = [[account imap4Connection] client];
+                          NGImap4Client *dstClient = [[account imap4Connection] client];
                           [[account imap4Connection] selectFolder: imapDestinationFolder];
                           messages = [result objectEnumerator];
                           result = nil;
@@ -803,7 +803,7 @@ static NSInteger _compareFetchResultsByUID (id entry1, id entry2, NSDictionary *
                               if ((content = [message valueForKey: @"message"]) != nil)
                                 {
                                   flags = [message valueForKey: @"flags"];
-                                  result = [client append: content toFolder: imapDestinationFolder withFlags: flags];
+                                  result = [dstClient append: content toFolder: imapDestinationFolder withFlags: flags];
                                   if ([[result objectForKey: @"result"] boolValue])
                                     result = nil;
                                   else


### PR DESCRIPTION
When moving mails across maiboxes, the mail is currently not being deleted from the source folder, as the corresponding `UID STORE` command is erroneously executed for the destination mailbox.