### PR TITLE
fix missing ld flag for ytnef in GNUmakefile

### DIFF
--- a/SoObjects/SOGo/GNUmakefile
+++ b/SoObjects/SOGo/GNUmakefile
@@ -229,7 +229,7 @@ endif
 ADDITIONAL_TOOL_LIBS += -Lobj -lSOGo$(LIBRARY_NAME_SUFFIX)
 ADDITIONAL_INCLUDE_DIRS += -I../../SOPE/
 ADDITIONAL_LIB_DIRS += -L../../SOPE/GDLContentStore/obj/
-ADDITIONAL_LDFLAGS += -lmemcached -lzip
+ADDITIONAL_LDFLAGS += -lmemcached -lzip -lytnef
 
 -include GNUmakefile.preamble
 ifneq ($(FHS_INSTALL_ROOT),)


### PR DESCRIPTION
fix undefined symbol: TNEFParseMemory when compiling from source