### PR TITLE
Fixing typo "attachements" to attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,9 +317,9 @@ All notable changes to this project will be documented in this file. See [standa
 * **eas:** Fix error 500 when SOGoCacheCleanup triggered cleanup with shibboleth 4.2.1. Fore refresh ticket in iFrame in this case ([7b711ea](https://github.com/Alinto/sogo/commit/7b711eabb346e7197c94880c8bfe264e0e3b6f0f) [5500ce7](https://github.com/Alinto/sogo/commit/5500ce7085a1c45a6858483b89fda5867f2aef36))
 * **js:** Fix display of body message when 'to' field is not filled in. Closes [#5721](https://bugs.sogo.nu/view.php?id=5721) ([6acb245](https://github.com/Alinto/sogo/commit/6acb245fec44bfc0bb7cf8b5b37dfd56b62089c5))
 * **js:** Fix JavaScript error when send mail from Addressbook. Fixes [#5750](https://bugs.sogo.nu/view.php?id=5750). ([3b0fbdd](https://github.com/Alinto/sogo/commit/3b0fbdd4f4584a010195daab9fa64c617e093c76))
-* **mail:** Fix images in attachements when replying to a mail. Fixes [#5731](https://bugs.sogo.nu/view.php?id=5731) ([dbd4e20](https://github.com/Alinto/sogo/commit/dbd4e20c344666a01cfb1fa5dfdd5547a59f0520))
+* **mail:** Fix images in attachments when replying to a mail. Fixes [#5731](https://bugs.sogo.nu/view.php?id=5731) ([dbd4e20](https://github.com/Alinto/sogo/commit/dbd4e20c344666a01cfb1fa5dfdd5547a59f0520))
 * **mail:** Fix invalid forward template when replying. Closes [#5726](https://bugs.sogo.nu/view.php?id=5726) ([d49ef40](https://github.com/Alinto/sogo/commit/d49ef4047a5c7f51850cf6e49cb3465b0dc7ac91))
-* **mail:** Removed attachements of images when replying to a mail. As the image is inline, the attachement shall be removed. ([0edd3f7](https://github.com/Alinto/sogo/commit/0edd3f757fc07aabd4270b393677cea6ff4a8ed6))
+* **mail:** Removed attachments of images when replying to a mail. As the image is inline, the attachement shall be removed. ([0edd3f7](https://github.com/Alinto/sogo/commit/0edd3f757fc07aabd4270b393677cea6ff4a8ed6))
 
 
 ### Localization

--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -2618,7 +2618,7 @@ Defaults to `inline` when unset.
 |Show recipients or sender full email in mailboxes if set to `YES`. Default value is `NO`.
 
 |U |SOGoMailHideInlineAttachments
-|Hide attachements for inline images if set to `YES`. Default value is `NO`.
+|Hide attachments for inline images if set to `YES`. Default value is `NO`.
 
 
 |U |SOGoMailCustomFullName

--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -1059,7 +1059,7 @@ static NSString    *userAgent      = nil;
 - (void) fetchMailForReplying: (SOGoMailObject *) sourceMail
                         toAll: (BOOL) toAll
 {
-  BOOL fromSentMailbox, shouldRetrieveAttachements;
+  BOOL fromSentMailbox, shouldRetrieveattachments;
   NSString *msgID;
   NSString *oldReferences;
   NSMutableDictionary *info;
@@ -1103,9 +1103,9 @@ static NSString    *userAgent      = nil;
   } else {
     [self setText: [NSString stringWithFormat: @"\n\n%@", [sourceMail contentForReply]]];
   }
-  shouldRetrieveAttachements = [[ud mailComposeMessageType] isEqualToString: @"html"];
+  shouldRetrieveattachments = [[ud mailComposeMessageType] isEqualToString: @"html"];
 
-  if (shouldRetrieveAttachements) {
+  if (shouldRetrieveattachments) {
     if ([sourceMail isEncrypted])
       [self _fetchAttachmentsFromEncryptedMail: sourceMail onlyImages: YES];
     else if ([sourceMail isOpaqueSigned])

--- a/UI/MailerUI/UIxMailListActions.m
+++ b/UI/MailerUI/UIxMailListActions.m
@@ -376,7 +376,7 @@
   }  
   NS_HANDLER
   {
-    [self logWithFormat: @"Error while parsing attachements for rendering bracket"];
+    [self logWithFormat: @"Error while parsing attachments for rendering bracket"];
   }
   NS_ENDHANDLER;
 

--- a/UI/PreferencesUI/Arabic.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Arabic.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Basque.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Basque.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Bosnian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Bosnian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standardna veličina fonta";

--- a/UI/PreferencesUI/BrazilianPortuguese.lproj/Localizable.strings
+++ b/UI/PreferencesUI/BrazilianPortuguese.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Inserir assinatura na resposta";
 "Insert signature on forward" = "Inserir assinatura ao encaminhar";
 "Show recipients or sender full email in mailboxes" = "Mostrar destinatários ou remetente do email completo nas caixas de correio";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Tamanho de fonte padrão";

--- a/UI/PreferencesUI/Bulgarian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Bulgarian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Размер на шрифта по подразбиране";

--- a/UI/PreferencesUI/Catalan.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Catalan.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Mida per defecte del tipus de lletra";

--- a/UI/PreferencesUI/ChineseChina.lproj/Localizable.strings
+++ b/UI/PreferencesUI/ChineseChina.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "默认字体大小";

--- a/UI/PreferencesUI/ChineseTaiwan.lproj/Localizable.strings
+++ b/UI/PreferencesUI/ChineseTaiwan.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Croatian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Croatian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Zadana veličina slova";

--- a/UI/PreferencesUI/Czech.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Czech.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Výchozí velikost písma";

--- a/UI/PreferencesUI/Danish.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Danish.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Indsæt signatur på svar";
 "Insert signature on forward" = "Indsæt signatur på videresend";
 "Show recipients or sender full email in mailboxes" = "Vis modtagere eller afsender fulde e-mail i postkasserne";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standard skriftstørrelse";

--- a/UI/PreferencesUI/Dutch.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Dutch.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standaard lettergrootte";

--- a/UI/PreferencesUI/English.lproj/Localizable.strings
+++ b/UI/PreferencesUI/English.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Finnish.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Finnish.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Oletuskirjasinkoko";

--- a/UI/PreferencesUI/French.lproj/Localizable.strings
+++ b/UI/PreferencesUI/French.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insérer la signature sur une réponse";
 "Insert signature on forward" = "Insérer la signature sur un transfert";
 "Show recipients or sender full email in mailboxes" = "Afficher l'email complet du destinataire ou expéditeur dans les boîtes aux lettres";
-"Hide attachements for inline images" = "Cacher les pièces jointes pour les images 'inline'";
+"Hide attachments for inline images" = "Cacher les pièces jointes pour les images 'inline'";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Taille de la police par défaut";

--- a/UI/PreferencesUI/Galician.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Galician.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Inserir firma na resposta";
 "Insert signature on forward" = "Inserir firma ao reenviar";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Tamaño de fonte por defecto.";

--- a/UI/PreferencesUI/German.lproj/Localizable.strings
+++ b/UI/PreferencesUI/German.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Signatur bei Antwort hinzufügen";
 "Insert signature on forward" = "Signatur bei Weiterleitung hinzufügen";
 "Show recipients or sender full email in mailboxes" = "Zeige die komplette E-Mail-Adresse des Empfängers oder des Senders in Postfächern";
-"Hide attachements for inline images" = "Verberge Anhänge für eingebettete Bilder";
+"Hide attachments for inline images" = "Verberge Anhänge für eingebettete Bilder";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standard-Schriftgröße";

--- a/UI/PreferencesUI/Hebrew.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Hebrew.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "ברירת מחדל גודל גופן";

--- a/UI/PreferencesUI/Hungarian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Hungarian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Aláírás beszúrása válasz esetén";
 "Insert signature on forward" = "Aláírás beszúrása továbbítás esetén";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Alapértelmezett betűméret";

--- a/UI/PreferencesUI/Icelandic.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Icelandic.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Indonesian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Indonesian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Ukuran font default";

--- a/UI/PreferencesUI/Italian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Italian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Grandezza carattere predefinita";

--- a/UI/PreferencesUI/Japanese.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Japanese.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "デフォルトのフォントサイズ";

--- a/UI/PreferencesUI/Kazakh.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Kazakh.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Әдепкі қаріп өлшемі";

--- a/UI/PreferencesUI/Latvian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Latvian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Noklusējuma fonta lielums";

--- a/UI/PreferencesUI/Lithuanian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Lithuanian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Parašas po atsakymu";
 "Insert signature on forward" = "Parašas po persiunčiamu laišku";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Numatytasis teksto dydis";

--- a/UI/PreferencesUI/Macedonian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Macedonian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Стандардна големина на фонтот";

--- a/UI/PreferencesUI/Montenegrin.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Montenegrin.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Podrazumijevana veličina fonta";

--- a/UI/PreferencesUI/NorwegianBokmal.lproj/Localizable.strings
+++ b/UI/PreferencesUI/NorwegianBokmal.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Sett inn signatur på svar";
 "Insert signature on forward" = "Sett inn signatur på videresending";
 "Show recipients or sender full email in mailboxes" = "Vis mottakere eller avsender av hele e-posten i innboksene";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standard skriftstørrelse ";

--- a/UI/PreferencesUI/NorwegianNynorsk.lproj/Localizable.strings
+++ b/UI/PreferencesUI/NorwegianNynorsk.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/Polish.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Polish.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Wstaw sygnaturę w odpowiedzi";
 "Insert signature on forward" = "Wstaw sygnaturę przy przekierowaniu";
 "Show recipients or sender full email in mailboxes" = "Pokazuj w skrzynkach pocztowych pełne adresy e-mail odbiorców lub nadawców";
-"Hide attachements for inline images" = "Ukryj załączniki obrazów w treści";
+"Hide attachments for inline images" = "Ukryj załączniki obrazów w treści";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Podstawowy rozmiar czcionki";

--- a/UI/PreferencesUI/Portuguese.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Portuguese.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Inserir assinatura nas respostas";
 "Insert signature on forward" = "Inserir assinatura no reencaminhamento";
 "Show recipients or sender full email in mailboxes" = "Mostrar destinatários ou endereço completo do remetente nas caixas de correio";
-"Hide attachements for inline images" = "Ocultar anexos para imagens em linha";
+"Hide attachments for inline images" = "Ocultar anexos para imagens em linha";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Tamanho da letra por defeito";

--- a/UI/PreferencesUI/Romanian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Romanian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Marime font implicită";

--- a/UI/PreferencesUI/Russian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Russian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Вставить подпись в ответе";
 "Insert signature on forward" = "Вставить подпись при пересылке";
 "Show recipients or sender full email in mailboxes" = "Показывать полную электронную почту получателей или отправителя в почтовых ящиках";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Размер шрифта по умолчанию";

--- a/UI/PreferencesUI/Serbian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Serbian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Подразуевана величина фонта";

--- a/UI/PreferencesUI/SerbianLatin.lproj/Localizable.strings
+++ b/UI/PreferencesUI/SerbianLatin.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Podrazuevana veličina fonta";

--- a/UI/PreferencesUI/Slovak.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Slovak.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Predvolená veľkosť písma";

--- a/UI/PreferencesUI/Slovenian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Slovenian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Privzeta velikost črk";

--- a/UI/PreferencesUI/SpanishArgentina.lproj/Localizable.strings
+++ b/UI/PreferencesUI/SpanishArgentina.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Tamaño de fuente por defecto";

--- a/UI/PreferencesUI/SpanishSpain.lproj/Localizable.strings
+++ b/UI/PreferencesUI/SpanishSpain.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Tamaño de fuente por defecto.";

--- a/UI/PreferencesUI/Swedish.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Swedish.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Standardteckenstorlek";

--- a/UI/PreferencesUI/TurkishTurkey.lproj/Localizable.strings
+++ b/UI/PreferencesUI/TurkishTurkey.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Varsayılan yazı büyüklüğü";

--- a/UI/PreferencesUI/Ukrainian.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Ukrainian.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Вставляти підпис у відповідь";
 "Insert signature on forward" = "Вставляти підпис при переадресації";
 "Show recipients or sender full email in mailboxes" = "Показувати повну електронну пошту одержувачів або відправника в поштових скриньках";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Розмір шрифта за замовчуванням";

--- a/UI/PreferencesUI/Welsh.lproj/Localizable.strings
+++ b/UI/PreferencesUI/Welsh.lproj/Localizable.strings
@@ -205,7 +205,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Maint ffont diofyn";

--- a/UI/Templates/PreferencesUI/UIxPreferences.wox
+++ b/UI/Templates/PreferencesUI/UIxPreferences.wox
@@ -710,8 +710,8 @@
                   ng-model="app.preferences.defaults.SOGoMailHideInlineAttachments"
                   ng-true-value="1"
                   ng-false-value="0"
-                  label:aria-label="Hide attachements for inline images">
-                <var:string label:value="Hide attachements for inline images"/>
+                  label:aria-label="Hide attachments for inline images">
+                <var:string label:value="Hide attachments for inline images"/>
               </md-checkbox>
             </div>
 


### PR DESCRIPTION
Mistyped word attachements replaced by correct one attachments