### PR TITLE
Update basque Localizable.strings

### DIFF
--- a/UI/Scheduler/Basque.lproj/Localizable.strings
+++ b/UI/Scheduler/Basque.lproj/Localizable.strings
@@ -205,10 +205,10 @@
 
 /* Appointments (participation state) */
 "partStat_NEEDS-ACTION" = "Beranduago berretsiko dut";
-"partStat_ACCEPTED" = "Zain egongo naiz";
-"partStat_DECLINED" = "Ez dut itxarongo";
-"partStat_TENTATIVE" = "Joan nintekeen";
-"partStat_DELEGATED" = "Eskuordetu dut";
+"partStat_ACCEPTED" = "Bertaratuko naiz";
+"partStat_DECLINED" = "Ez naiz bertaratuko";
+"partStat_TENTATIVE" = "Bertaratu ninteke";
+"partStat_DELEGATED" = "Eskuordetuko dut";
 "partStat_OTHER" = "Bestelakoak";
 
 /* Appointments (error messages) */


### PR DESCRIPTION
Some basque translations for appointment participation states are not correct.

Original text translates literally as:

"partStat_ACCEPTED" = "Zain egongo naiz"  -> I will be waiting
"partStat_DECLINED" = "Ez dut itxarongo"  -> I won't wait
"partStat_TENTATIVE" = "Joan nintekeen";  -> I could have gone
"partStat_DELEGATED" = "Eskuordetu dut"; -> I have delegated

These do not make much sense, and can be misleading for users. I am proposing the following translations:

 "partStat_ACCEPTED" = "Bertaratuko naiz" -> I will attend
"partStat_DECLINED" = "Ez naiz bertaratuko"  -> I won't attend
"partStat_TENTATIVE" = "Bertaratu ninteke";  -> I could attend / I might attend
"partStat_DELEGATED" = "Eskuordetuko dut"; -> I will delegate

I think these ones make much more sense and are clearer for what each options means.