### PR TITLE
fix(calendar): fix disabled change view buttons

### DIFF
--- a/UI/Templates/SchedulerUI/UIxCalMonthView.wox
+++ b/UI/Templates/SchedulerUI/UIxCalMonthView.wox
@@ -53,7 +53,6 @@
       </md-button>
       <a class="md-icon-button md-button"
          label:aria-label="Day"
-         ng-disabled="true"
          ng-click="calendar.changeView($event, 'day')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to day view"/></md-tooltip>
          <md-icon>view_day</md-icon>
@@ -66,6 +65,7 @@
       </a>
       <a class="md-icon-button md-button"
          label:aria-label="Month"
+         ng-disabled="true"
          ng-click="calendar.changeView($event, 'month')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to month view"/></md-tooltip>
          <md-icon>view_module</md-icon>

--- a/UI/Templates/SchedulerUI/UIxCalMulticolumnDayView.wox
+++ b/UI/Templates/SchedulerUI/UIxCalMulticolumnDayView.wox
@@ -53,7 +53,6 @@
       </md-button>
       <a class="md-icon-button md-button"
          label:aria-label="Day"
-         ng-disabled="true"
          ng-click="calendar.changeView($event, 'day')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to day view"/></md-tooltip>
          <md-icon>view_day</md-icon>
@@ -72,6 +71,7 @@
       </a>
       <a class="md-icon-button md-button"
          label:aria-label="Multicolumn Day View"
+         ng-disabled="true"
          ng-click="calendar.changeView($event, 'multicolumnday')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to multi-columns day view"/></md-tooltip>
          <md-icon>view_array</md-icon>

--- a/UI/Templates/SchedulerUI/UIxCalWeekView.wox
+++ b/UI/Templates/SchedulerUI/UIxCalWeekView.wox
@@ -53,13 +53,13 @@
       </md-button>
       <a class="md-icon-button md-button"
          label:aria-label="Day"
-         ng-disabled="true"
          ng-click="calendar.changeView($event, 'day')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to day view"/></md-tooltip>
          <md-icon>view_day</md-icon>
       </a>
       <a class="md-icon-button md-button"
          label:aria-label="Week"
+         ng-disabled="true"
          ng-click="calendar.changeView($event, 'week')">
          <md-tooltip md-direction="bottom"><var:string label:value="Switch to week view"/></md-tooltip>
          <md-icon>view_week</md-icon>


### PR DESCRIPTION
When viewing a calendar, 4 buttons allow to switch between the day,
week, month and multicolumnday views.  Each of these view show the
button to swith to the day view as disabled, regradless of which view is
in use.

Adjust markup to disable the button of the current view instead of the
one used to switch to the day view.
