### PR TITLE
Use pkgconfig to compute cflags for wbxml2 instead of hardcoding them

### DIFF
--- a/ActiveSync/GNUmakefile
+++ b/ActiveSync/GNUmakefile
@@ -34,7 +34,7 @@ ActiveSync_RESOURCE_FILES +=		\
 ADDITIONAL_OBJCFLAGS += -Wno-deprecated-declarations
 ADDITIONAL_INCLUDE_DIRS += -I../SOPE/ -I../SoObjects/
 ADDITIONAL_LIB_DIRS += -L../SOPE/GDLContentStore/obj/ -L../SOPE/NGCards/obj/
-ADDITIONAL_INCLUDE_DIRS += -I/usr/include/libwbxml-1.0/
+ADDITIONAL_INCLUDE_DIRS += $(shell pkg-config --cflags libwbxml2)
 ADDITIONAL_LDFLAGS += -Wl,--no-as-needed -lwbxml2
 
 -include GNUmakefile.preamble


### PR DESCRIPTION
libwbxml2 recently changed their API version from 1.0 to 1.1. Avoid a build failure by retrieving the include dir from the provided pkgconfig definition.