### PR TITLE
Fix minor issues on second factor authentication for mobile devices

### DIFF
--- a/UI/Templates/MainUI/SOGoRootPage.wox
+++ b/UI/Templates/MainUI/SOGoRootPage.wox
@@ -163,7 +163,7 @@
                     <md-input-container class="md-block">
                       <label><var:string label:value="Verification Code"/></label>
                       <md-icon>lock</md-icon>
-                      <input type="text"
+                      <input type="number" autocomplete="off"
                             ng-pattern="app.verificationCodePattern"
                             ng-model="app.creds.verificationCode"
                             ng-required="app.loginState == 'totpcode'"


### PR DESCRIPTION
- Ensure the TOTP input field only accept number, so it is more convenient on mobile devices.
- Disable history of the TOTP input, which is not necessary and confusing.

See https://bugs.sogo.nu//view.php?id=5524