### PR TITLE
feat(calendar): Make the Jitsi room prefix configurable

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -490,6 +490,12 @@ the jitsi server used for creating the meeting link.
 
 Defaults to `https://meet.jit.si` when unset.
 
+|D |SOGoCalendarJitsiRoomPrefix
+|Only used if SOGoCalendarEnableJitsiLink is set to YES. The string for
+the Jitsi room prefix used for creating the meeting link.
+
+Defaults to `SOGo_meeting/` when unset.
+
 |S |SOGoSAML2PrivateKeyLocation
 |The location of the SSL private key file on the filesystem that is used
 by SOGo to sign and encrypt communications with the SAML2 identity

--- a/SoObjects/SOGo/SOGoDomainDefaults.h
+++ b/SoObjects/SOGo/SOGoDomainDefaults.h
@@ -78,7 +78,7 @@
 - (BOOL) appointmentSendEMailNotifications;
 - (BOOL) foldersSendEMailNotifications;
 - (NSArray *) calendarDefaultRoles;
-- (NSString *) calendarJistiBaseUrl;
+- (NSString *) calendarJitsiBaseUrl;
 - (NSString *) calendarJitsiRoomPrefix;
 - (NSArray *) contactsDefaultRoles;
 - (NSArray *) refreshViewIntervals;

--- a/SoObjects/SOGo/SOGoDomainDefaults.h
+++ b/SoObjects/SOGo/SOGoDomainDefaults.h
@@ -79,6 +79,7 @@
 - (BOOL) foldersSendEMailNotifications;
 - (NSArray *) calendarDefaultRoles;
 - (NSString *) calendarJistiBaseUrl;
+- (NSString *) calendarJitsiRoomPrefix;
 - (NSArray *) contactsDefaultRoles;
 - (NSArray *) refreshViewIntervals;
 - (NSString *) subscriptionFolderFormat;

--- a/SoObjects/SOGo/SOGoDomainDefaults.m
+++ b/SoObjects/SOGo/SOGoDomainDefaults.m
@@ -179,6 +179,16 @@
   return jitsiBaseUrl;
 }
 
+- (NSString *) calendarJitsiRoomPrefix
+{
+  NSString *jitsiRoomPrefix;
+  jitsiRoomPrefix = [self stringForKey: @"SOGoCalendarJitsiRoomPrefix"];
+  if(!jitsiRoomPrefix)
+    jitsiRoomPrefix = @"SOGo_meeting/";
+
+  return jitsiRoomPrefix;
+}
+
 - (NSArray *) contactsDefaultRoles
 {
   return [self stringArrayForKey: @"SOGoContactsDefaultRoles"];

--- a/SoObjects/SOGo/SOGoDomainDefaults.m
+++ b/SoObjects/SOGo/SOGoDomainDefaults.m
@@ -169,7 +169,7 @@
   return [self stringArrayForKey: @"SOGoCalendarDefaultRoles"];
 }
 
-- (NSString *) calendarJistiBaseUrl
+- (NSString *) calendarJitsiBaseUrl
 {
   NSString *jitsiBaseUrl;
   jitsiBaseUrl = [self stringForKey: @"SOGoCalendarJitsiBaseUrl"];

--- a/UI/PreferencesUI/UIxJSONPreferences.m
+++ b/UI/PreferencesUI/UIxJSONPreferences.m
@@ -340,6 +340,8 @@ static SoProduct *preferencesProduct = nil;
   {
     if (![[defaults source] objectForKey: @"SOGoCalendarJitsiBaseUrl"])
       [[defaults source] setObject: [domainDefaults calendarJistiBaseUrl] forKey: @"SOGoCalendarJitsiBaseUrl"];
+    if (![[defaults source] objectForKey: @"SOGoCalendarJitsiRoomPrefix"])
+      [[defaults source] setObject: [domainDefaults calendarJitsiRoomPrefix] forKey: @"SOGoCalendarJitsiRoomPrefix"];
   }
 
   //

--- a/UI/PreferencesUI/UIxJSONPreferences.m
+++ b/UI/PreferencesUI/UIxJSONPreferences.m
@@ -334,12 +334,12 @@ static SoProduct *preferencesProduct = nil;
           [defaults setCalendarCategoriesColors: colors];
         }
     }
-  // Add the jisti link if needed
+  // Add the jitsi link if needed
   sd = [SOGoSystemDefaults sharedSystemDefaults];
   if([sd isCalendarJitsiLinkEnabled])
   {
     if (![[defaults source] objectForKey: @"SOGoCalendarJitsiBaseUrl"])
-      [[defaults source] setObject: [domainDefaults calendarJistiBaseUrl] forKey: @"SOGoCalendarJitsiBaseUrl"];
+      [[defaults source] setObject: [domainDefaults calendarJitsiBaseUrl] forKey: @"SOGoCalendarJitsiBaseUrl"];
     if (![[defaults source] objectForKey: @"SOGoCalendarJitsiRoomPrefix"])
       [[defaults source] setObject: [domainDefaults calendarJitsiRoomPrefix] forKey: @"SOGoCalendarJitsiRoomPrefix"];
   }

--- a/UI/WebServerResources/js/Scheduler/Component.service.js
+++ b/UI/WebServerResources/js/Scheduler/Component.service.js
@@ -840,8 +840,8 @@
   /**
    * @function hasJitsiUrl
    * @memberof Component.prototype
-   * @desc Check if the there is a jisti url
-   * @returns true if there is a jisti url
+   * @desc Check if the there is a jitsi url
+   * @returns true if there is a jitsi url
    */
   Component.prototype.hasJitsiUrl = function() {
     if (angular.isUndefined(this.attachUrls)) {

--- a/UI/WebServerResources/js/Scheduler/ComponentController.js
+++ b/UI/WebServerResources/js/Scheduler/ComponentController.js
@@ -316,9 +316,12 @@
 
     this.addJitsiUrl = function () {
       var jitsiBaseUrl = "https://meet.jit.si";
+      var jitsiRoomPrefix = "SOGo_meeting/";
       if(this.preferences.defaults && this.preferences.defaults.SOGoCalendarJitsiBaseUrl)
         jitsiBaseUrl = this.preferences.defaults.SOGoCalendarJitsiBaseUrl;
-      var jitsiUrl = jitsiBaseUrl + "/SOGo_meeting/" + crypto.randomUUID();
+      if(this.preferences.defaults && this.preferences.defaults.SOGoCalendarJitsiRoomPrefix)
+        jitsiRoomPrefix = this.preferences.defaults.SOGoCalendarJitsiRoomPrefix;
+      var jitsiUrl = jitsiBaseUrl + "/" + jitsiRoomPrefix + crypto.randomUUID();
       var i = this.component.addAttachUrl(jitsiUrl);
       focus('attachUrl_' + i);
     };


### PR DESCRIPTION
Some Jitsi servers do not support the use of a slash in the name of the meeting rooms. The hard-coded prefix of the room name makes it impossible to use with such servers, or the user would have to edit the prefix manually every time. At the same time, when using a slash, the name of the room displayed during the meeting remains only GUID, which looks ugly.

The newly added configuration option allows the administrator to set the default prefix of the name of the meeting room.

