### PR TITLE
fix: Fix typo 'attachements'

### DIFF
--- a/Documentation/SOGoInstallationGuide.asciidoc
+++ b/Documentation/SOGoInstallationGuide.asciidoc
@@ -2756,7 +2756,7 @@ Defaults to `inline` when unset.
 |Show recipients or sender full email in mailboxes if set to `YES`. Default value is `NO`.
 
 |U |SOGoMailHideInlineAttachments
-|Hide attachements for inline images if set to `YES`. Default value is `NO`.
+|Hide attachments for inline images if set to `YES`. Default value is `NO`.
 
 
 |U |SOGoMailCustomFullName

--- a/UI/MailerUI/UIxMailListActions.m
+++ b/UI/MailerUI/UIxMailListActions.m
@@ -376,7 +376,7 @@
   }  
   NS_HANDLER
   {
-    [self logWithFormat: @"Error while parsing attachements for rendering bracket"];
+    [self logWithFormat: @"Error while parsing attachments for rendering bracket"];
   }
   NS_ENDHANDLER;
 

--- a/UI/PreferencesUI/English.lproj/Localizable.strings
+++ b/UI/PreferencesUI/English.lproj/Localizable.strings
@@ -206,7 +206,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachements for inline images" = "Hide attachements for inline images";
+"Hide attachments for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/PreferencesUI/English.lproj/Localizable.strings
+++ b/UI/PreferencesUI/English.lproj/Localizable.strings
@@ -206,7 +206,7 @@
 "Insert signature on reply" = "Insert signature on reply";
 "Insert signature on forward" = "Insert signature on forward";
 "Show recipients or sender full email in mailboxes" = "Show recipients or sender full email in mailboxes";
-"Hide attachments for inline images" = "Hide attachments for inline images";
+"Hide attachements for inline images" = "Hide attachments for inline images";
 
 /* Base font size for messages composed in HTML */
 "Default font size" = "Default font size";

--- a/UI/Templates/PreferencesUI/UIxPreferences.wox
+++ b/UI/Templates/PreferencesUI/UIxPreferences.wox
@@ -716,8 +716,8 @@
                   ng-model="app.preferences.defaults.SOGoMailHideInlineAttachments"
                   ng-true-value="1"
                   ng-false-value="0"
-                  label:aria-label="Hide attachements for inline images">
-                <var:string label:value="Hide attachements for inline images"/>
+                  label:aria-label="Hide attachments for inline images">
+                <var:string label:value="Hide attachments for inline images"/>
               </md-checkbox>
             </div>
 

--- a/UI/Templates/PreferencesUI/UIxPreferences.wox
+++ b/UI/Templates/PreferencesUI/UIxPreferences.wox
@@ -717,7 +717,7 @@
                   ng-true-value="1"
                   ng-false-value="0"
                   label:aria-label="Hide attachments for inline images">
-                <var:string label:value="Hide attachments for inline images"/>
+                <var:string label:value="Hide attachements for inline images"/>
               </md-checkbox>
             </div>
 


### PR DESCRIPTION
The SOGo interface uses the term 'attachements' for the English language. This word does not exist in the English dictionary (though it does in French, the project's origin).

See: https://dictionary.cambridge.org/spellcheck/english/?q=attachement

A PR in 2024, #354, addressed this issue as well, but has been closed because "Translations are managed in Transifex". I cannot find a feature to update origin keys (EN) in Transifex, so hence this new PR. 