### PR TITLE
Add subject validation before sending email

### DIFF
--- a/UI/MailerUI/UIxMailEditor.m
+++ b/UI/MailerUI/UIxMailEditor.m
@@ -838,9 +838,12 @@ static NSArray *infoKeys = nil;
   if (![self hasOneOrMoreRecipients])
     error = [NSException exceptionWithHTTPStatus: 400 /* Bad Request */
                                           reason: [self labelForKey: @"error_missingrecipients"]];
+  else if (![self subject] || [[self subject] length] == 0 || [[self subject] stringByTrimmingSpaces] length] == 0)
+    error = [NSException exceptionWithHTTPStatus: 400 /* Bad Request */
+                                          reason: [self labelForKey: @"error_missingsubject"]];
   else
     error = nil;
-  
+
   return error;
 }
 


### PR DESCRIPTION
- Validate that subject field is not empty when sending
- Check for nil, empty string, or whitespace-only subject
- Use existing localization key 'error_missingsubject' which prompts user for confirmation