### PR TITLE
Fix duplicate RRULE and VALARM scrubbing for CalDAV objects

### DIFF
--- a/SOPE/NGCards/iCalEntityObject.h
+++ b/SOPE/NGCards/iCalEntityObject.h
@@ -124,6 +124,7 @@ typedef enum
 - (void) addToAlarms: (id) _alarm;
 - (NSArray *) alarms;
 - (BOOL) hasAlarms;
+- (BOOL) removeDuplicateAlarms;
 
 /* comparisons */
 - (NSComparisonResult) compare: (iCalEntityObject *) otherObject;

--- a/SOPE/NGCards/iCalEntityObject.m
+++ b/SOPE/NGCards/iCalEntityObject.m
@@ -21,6 +21,7 @@
 
 #import <Foundation/NSArray.h>
 #import <Foundation/NSException.h>
+#import <Foundation/NSSet.h>
 #import <Foundation/NSURL.h>
 #import <Foundation/NSValue.h>
 
@@ -401,6 +402,46 @@
 - (NSArray *) alarms
 {
   return [self childrenWithTag: @"valarm"];
+}
+
+/* RFC 5545 section 3.6.6 allows any number of VALARMs, so only alarms that
+   serialize identically are dropped. Two alarms sharing an RFC 9074 UID but
+   differing otherwise are left alone: one of them may carry an ACKNOWLEDGED
+   the other lacks, and discarding it would let a dismissed alarm fire again. */
+- (BOOL) removeDuplicateAlarms
+{
+  NSMutableArray *duplicateAlarms;
+  NSMutableSet *alarmStrings;
+  NSEnumerator *allAlarms;
+  iCalAlarm *currentAlarm;
+  NSString *currentAlarmString;
+  NSArray *alarms;
+
+  alarms = [self alarms];
+  if ([alarms count] < 2)
+    return NO;
+
+  duplicateAlarms = [NSMutableArray array];
+  alarmStrings = [NSMutableSet set];
+
+  allAlarms = [alarms objectEnumerator];
+  while ((currentAlarm = [allAlarms nextObject]))
+    {
+      currentAlarmString = [currentAlarm versitString];
+      if ([alarmStrings containsObject: currentAlarmString])
+        [duplicateAlarms addObject: currentAlarm];
+      else
+        [alarmStrings addObject: currentAlarmString];
+    }
+
+  allAlarms = [duplicateAlarms objectEnumerator];
+  while ((currentAlarm = [allAlarms nextObject]))
+    {
+      [currentAlarm setParent: nil];
+      [children removeObjectIdenticalTo: currentAlarm];
+    }
+
+  return ([duplicateAlarms count] > 0);
 }
 
 - (void) setAttach: (NSArray *) _value

--- a/SOPE/NGCards/iCalRepeatableEntityObject.h
+++ b/SOPE/NGCards/iCalRepeatableEntityObject.h
@@ -43,6 +43,7 @@
 - (BOOL)hasRecurrenceRules;
 - (NSArray *)recurrenceRules;
 - (NSArray *)recurrenceRulesWithTimeZone: (id) timezone;
+- (BOOL) removeDuplicateRecurrenceRules;
 
 - (void) removeAllRecurrenceDates;
 - (void) addToRecurrenceDates: (NSCalendarDate *) _rdate;

--- a/SOPE/NGCards/iCalRepeatableEntityObject.m
+++ b/SOPE/NGCards/iCalRepeatableEntityObject.m
@@ -86,6 +86,41 @@
   return [self rules: rules withTimeZone: timezone];
 }
 
+- (BOOL) removeDuplicateRecurrenceRules
+{
+  NSArray *rules;
+  NSMutableArray *duplicateRules, *ruleStrings;
+  NSEnumerator *allRules;
+  iCalRecurrenceRule *currentRule;
+  NSString *currentRuleString;
+
+  rules = [self recurrenceRules];
+  if ([rules count] < 2)
+    return NO;
+
+  duplicateRules = [NSMutableArray array];
+  ruleStrings = [NSMutableArray array];
+
+  allRules = [rules objectEnumerator];
+  while ((currentRule = [allRules nextObject]))
+    {
+      currentRuleString = [currentRule versitString];
+      if ([ruleStrings containsObject: currentRuleString])
+        [duplicateRules addObject: currentRule];
+      else
+        [ruleStrings addObject: currentRuleString];
+    }
+
+  allRules = [duplicateRules objectEnumerator];
+  while ((currentRule = [allRules nextObject]))
+    {
+      [currentRule setParent: nil];
+      [children removeObjectIdenticalTo: currentRule];
+    }
+
+  return ([duplicateRules count] > 0);
+}
+
 - (void) removeAllRecurrenceDates
 {
   [self removeChildren: [self childrenWithTag: @"rdate"]];

--- a/SoObjects/Appointments/SOGoAppointmentObject.m
+++ b/SoObjects/Appointments/SOGoAppointmentObject.m
@@ -66,9 +66,9 @@
 
 #import "SOGoAppointmentObject.h"
 
-@interface SOGoCalendarComponent (DuplicateRecurrenceRules)
+@interface SOGoCalendarComponent (DuplicateCalendarProperties)
 
-- (BOOL) _removeDuplicateRecurrenceRulesFromCalendar: (iCalCalendar *) calendar;
+- (BOOL) _removeDuplicatesFromCalendar: (iCalCalendar *) calendar;
 
 @end
 
@@ -2244,7 +2244,7 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
       [self _adjustPartStatInRequestCalendar: calendar];
     }
 
-  [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
+  [self _removeDuplicatesFromCalendar: calendar];
       
   //
   // We first check if it's a new event

--- a/SoObjects/Appointments/SOGoAppointmentObject.m
+++ b/SoObjects/Appointments/SOGoAppointmentObject.m
@@ -66,6 +66,12 @@
 
 #import "SOGoAppointmentObject.h"
 
+@interface SOGoCalendarComponent (DuplicateRecurrenceRules)
+
+- (BOOL) _removeDuplicateRecurrenceRulesFromCalendar: (iCalCalendar *) calendar;
+
+@end
+
 @implementation SOGoAppointmentObject
 
 - (NSString *) componentTag
@@ -2237,6 +2243,8 @@ inRecurrenceExceptionsForEvent: (iCalEvent *) theEvent
       [self adjustClassificationInRequestCalendar: calendar];
       [self _adjustPartStatInRequestCalendar: calendar];
     }
+
+  [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
       
   //
   // We first check if it's a new event

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -256,7 +256,7 @@ static NSArray *allowed_tags = nil;
   [component setUid: uid];
 }
 
-- (BOOL) _removeDuplicateRecurrenceRulesFromCalendar: (iCalCalendar *) calendar
+- (BOOL) _removeDuplicatesFromCalendar: (iCalCalendar *) calendar
 {
   iCalRepeatableEntityObject *currentComponent;
   NSArray *allComponents;
@@ -270,36 +270,69 @@ static NSArray *allowed_tags = nil;
     {
       currentComponent = (iCalRepeatableEntityObject *) [allComponents objectAtIndex: i];
       modified = [currentComponent removeDuplicateRecurrenceRules] || modified;
+      modified = [currentComponent removeDuplicateAlarms] || modified;
     }
 
   return modified;
 }
 
-- (NSString *) _contentByRemovingDuplicateRecurrenceRulesFromString: (NSString *) iCalString
+/* RFC 5545 3.1 permits a fold between any two characters, so a marker has to be
+   matched against unfolded content. Still far cheaper than parsing, which is
+   what the marker check exists to avoid. */
+- (NSString *) _unfoldedString: (NSString *) iCalString
+{
+  NSMutableString *unfolded;
+  NSArray *folds;
+  NSUInteger count, i;
+
+  folds = [NSArray arrayWithObjects: @"\r\n ", @"\r\n\t", @"\n ", @"\n\t", nil];
+  unfolded = [NSMutableString stringWithString: iCalString];
+  count = [folds count];
+  for (i = 0; i < count; i++)
+    [unfolded replaceOccurrencesOfString: [folds objectAtIndex: i]
+                              withString: @""
+                                 options: NSLiteralSearch
+                                   range: NSMakeRange (0, [unfolded length])];
+
+  return unfolded;
+}
+
+- (BOOL) _stringRepeatsMarker: (NSString *) marker
+                     inString: (NSString *) iCalString
+{
+  NSRange firstRange, secondRange;
+
+  firstRange = [iCalString rangeOfString: marker
+                                 options: NSCaseInsensitiveSearch];
+  if (firstRange.location == NSNotFound)
+    return NO;
+
+  secondRange
+    = [iCalString rangeOfString: marker
+                        options: NSCaseInsensitiveSearch
+                          range: NSMakeRange (NSMaxRange (firstRange),
+                                              [iCalString length] - NSMaxRange (firstRange))];
+
+  return (secondRange.location != NSNotFound);
+}
+
+- (NSString *) _contentByRemovingDuplicatesFromString: (NSString *) iCalString
 {
   iCalCalendar *calendar;
-  NSRange firstRange, secondRange;
+  NSString *unfolded;
   BOOL modified;
 
   if (![iCalString length])
     return iCalString;
 
-  /* Avoid parsing the common single-RRULE case; duplicates need two markers. */
-  firstRange = [iCalString rangeOfString: @"RRULE"
-                                 options: NSCaseInsensitiveSearch];
-  if (firstRange.location == NSNotFound)
-    return iCalString;
-
-  secondRange
-    = [iCalString rangeOfString: @"RRULE"
-                        options: NSCaseInsensitiveSearch
-                          range: NSMakeRange (NSMaxRange (firstRange),
-                                              [iCalString length] - NSMaxRange (firstRange))];
-  if (secondRange.location == NSNotFound)
+  /* Skip parsing when no marker repeats, so no duplicate is possible. */
+  unfolded = [self _unfoldedString: iCalString];
+  if (![self _stringRepeatsMarker: @"RRULE" inString: unfolded]
+      && ![self _stringRepeatsMarker: @"BEGIN:VALARM" inString: unfolded])
     return iCalString;
 
   calendar = [iCalCalendar parseSingleFromSource: iCalString];
-  modified = [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
+  modified = [self _removeDuplicatesFromCalendar: calendar];
 
   if (modified)
     iCalString = [calendar versitString];
@@ -322,14 +355,14 @@ static NSArray *allowed_tags = nil;
       || [[self ownerInContext: context] isEqualToString: [[context activeUser] login]]
       || ![sm validatePermission: SOGoCalendarPerm_ViewAllComponent
 	      onObject: self inContext: context])
-    iCalString = [self _contentByRemovingDuplicateRecurrenceRulesFromString: content];
+    iCalString = [self _contentByRemovingDuplicatesFromString: content];
   else if (![sm validatePermission: SOGoCalendarPerm_ViewDAndT
 		onObject: self inContext: context])
     {
       tmpCalendar = [[self calendar: NO secure: NO] mutableCopy];
 
       // We filter all components, in case we have RECURRENCE-ID
-      [self _removeDuplicateRecurrenceRulesFromCalendar: tmpCalendar];
+      [self _removeDuplicatesFromCalendar: tmpCalendar];
       allComponents = [tmpCalendar childrenWithTag: [self componentTag]];
 
       for (i = 0; i < [allComponents count]; i++)
@@ -482,7 +515,7 @@ static NSArray *allowed_tags = nil;
   NSUInteger count, max;
 
   calendar = [self calendar: NO secure: YES];
-  [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
+  [self _removeDuplicatesFromCalendar: calendar];
   allComponents = [calendar childrenWithTag: [self componentTag]];
   max = [allComponents count];
   for (count = 0; count < max; count++)
@@ -537,6 +570,7 @@ static NSArray *allowed_tags = nil;
     if ([iCalString length] > 0)
     {
       ASSIGN (*calendar, [iCalCalendar parseSingleFromSource: iCalString]);
+      [self _removeDuplicatesFromCalendar: *calendar];
       if (!secure)
         originalCalendar = [*calendar copy];
     }
@@ -726,6 +760,7 @@ static NSArray *allowed_tags = nil;
   NSString *newUid;
 
   [newObject removeDuplicateRecurrenceRules];
+  [newObject removeDuplicateAlarms];
 
   if (!isNew
       && [newObject isRecurrent])
@@ -765,7 +800,7 @@ static NSArray *allowed_tags = nil;
                     baseVersion: (unsigned int) newVersion
 {
   if ([theComponent isKindOfClass: [iCalCalendar class]])
-    [self _removeDuplicateRecurrenceRulesFromCalendar: theComponent];
+    [self _removeDuplicatesFromCalendar: theComponent];
 
   return [super saveComponent: theComponent
                   baseVersion: newVersion];

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -256,6 +256,57 @@ static NSArray *allowed_tags = nil;
   [component setUid: uid];
 }
 
+- (BOOL) _removeDuplicateRecurrenceRulesFromCalendar: (iCalCalendar *) calendar
+{
+  iCalRepeatableEntityObject *currentComponent;
+  NSArray *allComponents;
+  BOOL modified;
+  int i;
+
+  allComponents = [calendar childrenWithTag: [self componentTag]];
+  modified = NO;
+
+  for (i = 0; i < [allComponents count]; i++)
+    {
+      currentComponent = (iCalRepeatableEntityObject *) [allComponents objectAtIndex: i];
+      modified = [currentComponent removeDuplicateRecurrenceRules] || modified;
+    }
+
+  return modified;
+}
+
+- (NSString *) _contentByRemovingDuplicateRecurrenceRulesFromString: (NSString *) iCalString
+{
+  iCalCalendar *calendar;
+  NSRange firstRange, secondRange;
+  BOOL modified;
+
+  if (![iCalString length])
+    return iCalString;
+
+  /* Avoid parsing the common single-RRULE case; duplicates need two markers. */
+  firstRange = [iCalString rangeOfString: @"RRULE"
+                                 options: NSCaseInsensitiveSearch];
+  if (firstRange.location == NSNotFound)
+    return iCalString;
+
+  secondRange
+    = [iCalString rangeOfString: @"RRULE"
+                        options: NSCaseInsensitiveSearch
+                          range: NSMakeRange (NSMaxRange (firstRange),
+                                              [iCalString length] - NSMaxRange (firstRange))];
+  if (secondRange.location == NSNotFound)
+    return iCalString;
+
+  calendar = [iCalCalendar parseSingleFromSource: iCalString];
+  modified = [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
+
+  if (modified)
+    iCalString = [calendar versitString];
+
+  return iCalString;
+}
+
 - (NSString *) secureContentAsString
 {
   iCalRepeatableEntityObject *tmpComponent;
@@ -271,13 +322,14 @@ static NSArray *allowed_tags = nil;
       || [[self ownerInContext: context] isEqualToString: [[context activeUser] login]]
       || ![sm validatePermission: SOGoCalendarPerm_ViewAllComponent
 	      onObject: self inContext: context])
-    iCalString = content;
+    iCalString = [self _contentByRemovingDuplicateRecurrenceRulesFromString: content];
   else if (![sm validatePermission: SOGoCalendarPerm_ViewDAndT
 		onObject: self inContext: context])
     {
       tmpCalendar = [[self calendar: NO secure: NO] mutableCopy];
 
       // We filter all components, in case we have RECURRENCE-ID
+      [self _removeDuplicateRecurrenceRulesFromCalendar: tmpCalendar];
       allComponents = [tmpCalendar childrenWithTag: [self componentTag]];
 
       for (i = 0; i < [allComponents count]; i++)
@@ -426,10 +478,11 @@ static NSArray *allowed_tags = nil;
 {
   iCalCalendar *calendar;
   NSArray *allComponents;
-  iCalEntityObject *currentComponent;
+  iCalRepeatableEntityObject *currentComponent;
   NSUInteger count, max;
 
   calendar = [self calendar: NO secure: YES];
+  [self _removeDuplicateRecurrenceRulesFromCalendar: calendar];
   allComponents = [calendar childrenWithTag: [self componentTag]];
   max = [allComponents count];
   for (count = 0; count < max; count++)

--- a/SoObjects/Appointments/SOGoCalendarComponent.m
+++ b/SoObjects/Appointments/SOGoCalendarComponent.m
@@ -725,6 +725,8 @@ static NSArray *allowed_tags = nil;
 {
   NSString *newUid;
 
+  [newObject removeDuplicateRecurrenceRules];
+
   if (!isNew
       && [newObject isRecurrent])
     // We update an repeating event -- update exception dates
@@ -757,6 +759,16 @@ static NSArray *allowed_tags = nil;
 {
   [newObject setLastModified: [NSCalendarDate calendarDate]];
   return [self saveCalendar: [newObject parent]];
+}
+
+- (NSException *) saveComponent: (id) theComponent
+                    baseVersion: (unsigned int) newVersion
+{
+  if ([theComponent isKindOfClass: [iCalCalendar class]])
+    [self _removeDuplicateRecurrenceRulesFromCalendar: theComponent];
+
+  return [super saveComponent: theComponent
+                  baseVersion: newVersion];
 }
 
 - (NSException *) saveComponent: (iCalRepeatableEntityObject *) newEvent

--- a/Tests/Unit/GNUmakefile
+++ b/Tests/Unit/GNUmakefile
@@ -18,6 +18,7 @@ $(TEST_TOOL)_OBJC_FILES += \
 	TestVersit.m \
 	TestiCalTimeZonePeriod.m \
 	TestiCalRecurrenceCalculator.m \
+	TestiCalRepeatableEntityObject.m \
 	\
 	TestSBJsonParser.m \
 	\

--- a/Tests/Unit/TestiCalRepeatableEntityObject.m
+++ b/Tests/Unit/TestiCalRepeatableEntityObject.m
@@ -16,8 +16,11 @@
  * Boston, MA 02111-1307, USA.
  */
 
+#import <NGCards/iCalAlarm.h>
 #import <NGCards/iCalCalendar.h>
+#import <NGCards/iCalEntityObject.h>
 #import <NGCards/iCalRepeatableEntityObject.h>
+#import <NGCards/iCalTrigger.h>
 
 #import "SOGoTest.h"
 
@@ -57,6 +60,158 @@
   testEquals([[rules objectAtIndex: 1] versitString],
              @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR");
   failIf([event removeDuplicateRecurrenceRules]);
+}
+
+/* Alarms that differ must survive. */
+- (void) test_removeDuplicateAlarmsKeepsDistinctAlarms
+{
+  iCalCalendar *calendar;
+  iCalEntityObject *event;
+  NSArray *alarms;
+  NSString *versit;
+
+  versit = @"BEGIN:VCALENDAR\r\n"
+    @"VERSION:2.0\r\n"
+    @"BEGIN:VEVENT\r\n"
+    @"UID:duplicate-valarm\r\n"
+    @"DTSTART:20260211T123000Z\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-P1D\r\n"
+    @"DESCRIPTION:one day\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT2H\r\n"
+    @"DESCRIPTION:two hours\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-P1D\r\n"
+    @"DESCRIPTION:one day\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"END:VALARM\r\n"
+    @"END:VEVENT\r\n"
+    @"END:VCALENDAR";
+  calendar = [iCalCalendar parseSingleFromSource: versit];
+  event = (iCalEntityObject *) [calendar firstChildWithTag: @"vevent"];
+
+  test([event removeDuplicateAlarms]);
+
+  /* Check which alarms survive because the count alone does not prove that
+     every distinct alarm remains. */
+  alarms = [event alarms];
+  testWithMessage([alarms count] == 3,
+                  ([NSString stringWithFormat: @"expected 3 alarms, got %lu",
+                             (unsigned long) [alarms count]]));
+  testEquals([[[alarms objectAtIndex: 0] trigger] flattenedValuesForKey: @""],
+             @"-PT10M");
+  testEquals([[[alarms objectAtIndex: 1] trigger] flattenedValuesForKey: @""],
+             @"-P1D");
+  testEquals([[[alarms objectAtIndex: 2] trigger] flattenedValuesForKey: @""],
+             @"-PT2H");
+  failIf([event removeDuplicateAlarms]);
+}
+
+/* An acknowledged alarm must not be dropped in favour of an identical-looking
+   one that was never dismissed, or RFC 9074 section 6.1 suppression is lost and
+   the alarm fires again. Sharing a UID is not enough to call them the same. */
+- (void) test_removeDuplicateAlarmsKeepsAcknowledgedAlarm
+{
+  iCalCalendar *calendar;
+  iCalEntityObject *event;
+  NSString *versit;
+
+  versit = @"BEGIN:VCALENDAR\r\n"
+    @"VERSION:2.0\r\n"
+    @"BEGIN:VEVENT\r\n"
+    @"UID:shared-alarm-uid\r\n"
+    @"DTSTART:20260211T123000Z\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"ACKNOWLEDGED:20260211T121500Z\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:ten minutes\r\n"
+    @"ACKNOWLEDGED:20260211T121500Z\r\n"
+    @"END:VALARM\r\n"
+    @"END:VEVENT\r\n"
+    @"END:VCALENDAR";
+  calendar = [iCalCalendar parseSingleFromSource: versit];
+  event = (iCalEntityObject *) [calendar firstChildWithTag: @"vevent"];
+
+  test([event removeDuplicateAlarms]);
+  testWithMessage([[event alarms] count] == 2,
+                  ([NSString stringWithFormat: @"expected 2 alarms, got %lu",
+                             (unsigned long) [[event alarms] count]]));
+  failIf([event removeDuplicateAlarms]);
+}
+
+/* A difference in any serialized property makes alarms distinct. */
+- (void) test_removeDuplicateAlarmsKeepsExtensionDifferences
+{
+  iCalCalendar *calendar;
+  iCalEntityObject *event;
+  NSString *versit;
+
+  versit = @"BEGIN:VCALENDAR\r\n"
+    @"VERSION:2.0\r\n"
+    @"BEGIN:VEVENT\r\n"
+    @"UID:clean-valarm\r\n"
+    @"DTSTART:20260211T123000Z\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:popup\r\n"
+    @"X-ALARM-COLOR:RED\r\n"
+    @"END:VALARM\r\n"
+    @"BEGIN:VALARM\r\n"
+    @"ACTION:DISPLAY\r\n"
+    @"TRIGGER:-PT10M\r\n"
+    @"DESCRIPTION:popup\r\n"
+    @"X-ALARM-COLOR:BLUE\r\n"
+    @"END:VALARM\r\n"
+    @"END:VEVENT\r\n"
+    @"END:VCALENDAR";
+  calendar = [iCalCalendar parseSingleFromSource: versit];
+  event = (iCalEntityObject *) [calendar firstChildWithTag: @"vevent"];
+
+  failIf([event removeDuplicateAlarms]);
+  testWithMessage([[event alarms] count] == 2,
+                  ([NSString stringWithFormat: @"expected 2 alarms, got %lu",
+                             (unsigned long) [[event alarms] count]]));
+  testWithMessage([[[[event alarms] objectAtIndex: 0] versitString]
+                    rangeOfString: @"X-ALARM-COLOR:RED"].location != NSNotFound,
+                  @"red alarm was not preserved");
+  testWithMessage([[[[event alarms] objectAtIndex: 1] versitString]
+                    rangeOfString: @"X-ALARM-COLOR:BLUE"].location != NSNotFound,
+                  @"blue alarm was not preserved");
 }
 
 @end

--- a/Tests/Unit/TestiCalRepeatableEntityObject.m
+++ b/Tests/Unit/TestiCalRepeatableEntityObject.m
@@ -1,0 +1,62 @@
+/* TestiCalRepeatableEntityObject.m - this file is part of SOGo
+ *
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This file is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#import <NGCards/iCalCalendar.h>
+#import <NGCards/iCalRepeatableEntityObject.h>
+
+#import "SOGoTest.h"
+
+@interface TestiCalRepeatableEntityObject : SOGoTest
+@end
+
+@implementation TestiCalRepeatableEntityObject
+
+- (void) test_removeDuplicateRecurrenceRules
+{
+  iCalCalendar *calendar;
+  iCalRepeatableEntityObject *event;
+  NSArray *rules;
+  NSString *versit;
+
+  versit = @"BEGIN:VCALENDAR\r\n"
+    @"VERSION:2.0\r\n"
+    @"BEGIN:VEVENT\r\n"
+    @"UID:duplicate-rrule\r\n"
+    @"DTSTART:20260211T123000Z\r\n"
+    @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE\r\n"
+    @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE\r\n"
+    @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR\r\n"
+    @"END:VEVENT\r\n"
+    @"END:VCALENDAR";
+  calendar = [iCalCalendar parseSingleFromSource: versit];
+  event = (iCalRepeatableEntityObject *) [calendar firstChildWithTag: @"vevent"];
+
+  test([event removeDuplicateRecurrenceRules]);
+
+  rules = [event recurrenceRules];
+  testWithMessage([rules count] == 2,
+                  ([NSString stringWithFormat: @"expected 2 recurrence rules, got %lu",
+                             (unsigned long) [rules count]]));
+  testEquals([[rules objectAtIndex: 0] versitString],
+             @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE");
+  testEquals([[rules objectAtIndex: 1] versitString],
+             @"RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR");
+  failIf([event removeDuplicateRecurrenceRules]);
+}
+
+@end

--- a/Tests/spec/CalDAVPropertiesSpec.js
+++ b/Tests/spec/CalDAVPropertiesSpec.js
@@ -165,5 +165,11 @@ END:VCALENDAR`
     expect(fridayRules.length)
       .withContext(`Different recurrence rule is preserved`)
       .toBe(1)
+
+    const dirtySerializedLength = Buffer.byteLength(`${event.replace(/\n/g, '\r\n')}\r\n`, 'utf8')
+    const [objectProperties] = await webdav.propfindWebdav(resource + filename, ['getcontentlength'])
+    expect(Number(objectProperties.props.getcontentlength))
+      .withContext(`Persisted calendar object is normalized on save`)
+      .toBeLessThan(dirtySerializedLength)
   })
 })

--- a/Tests/spec/CalDAVPropertiesSpec.js
+++ b/Tests/spec/CalDAVPropertiesSpec.js
@@ -130,4 +130,40 @@ END:VCALENDAR`
       .withContext(`Returned vCalendar matches ${filename}`)
       .toBe(true)
   })
+
+  it("calendar-multiget removes exact duplicate recurrence rules", async function() {
+    const filename = `duplicate-rrule.ics`
+    const event = `BEGIN:VCALENDAR
+PRODID:-//Inverse//Event Generator//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:duplicate-rrule
+SUMMARY:Duplicate recurrence rule
+DTSTART:20260211T123000Z
+DTEND:20260211T140000Z
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR
+END:VEVENT
+END:VCALENDAR`
+
+    let response = await webdav.createCalendarObject(resource, filename, event)
+    expect(response.status).toBe(201)
+
+    response = await webdav.calendarMultiGet(resource, filename)
+    expect(response.length)
+      .withContext(`Number of results from calendar-multiget`)
+      .toBe(1)
+
+    const calendarData = response[0].props.calendarData.replace(/\r\n/g, '\n')
+    const wednesdayRules = calendarData.match(/^RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE$/gm) || []
+    const fridayRules = calendarData.match(/^RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=FR$/gm) || []
+
+    expect(wednesdayRules.length)
+      .withContext(`Duplicated recurrence rule is returned once`)
+      .toBe(1)
+    expect(fridayRules.length)
+      .withContext(`Different recurrence rule is preserved`)
+      .toBe(1)
+  })
 })

--- a/Tests/spec/CalDAVPropertiesSpec.js
+++ b/Tests/spec/CalDAVPropertiesSpec.js
@@ -172,4 +172,61 @@ END:VCALENDAR`
       .withContext(`Persisted calendar object is normalized on save`)
       .toBeLessThan(dirtySerializedLength)
   })
+
+  it("calendar-multiget removes only exact duplicate alarms", async function() {
+    const filename = `duplicate-alarm.ics`
+    const event = `BEGIN:VCALENDAR
+PRODID:-//Inverse//Event Generator//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:duplicate-alarm
+SUMMARY:Duplicate alarm
+DTSTART:20260211T123000Z
+DTEND:20260211T140000Z
+BEGIN:VALARM
+UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22
+ACTION:DISPLAY
+TRIGGER:-PT10M
+DESCRIPTION:ten minutes
+END:VALARM
+BEGIN:VALARM
+UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22
+ACTION:DISPLAY
+TRIGGER:-PT10M
+DESCRIPTION:ten minutes
+END:VALARM
+BEGIN:VALARM
+UID:37e0f1a4-6d0c-4a0e-9d3b-6b6f0f5c1a22
+ACTION:DISPLAY
+TRIGGER:-PT10M
+DESCRIPTION:ten minutes
+ACKNOWLEDGED:20260211T121500Z
+END:VALARM
+END:VEVENT
+END:VCALENDAR`
+
+    let response = await webdav.createCalendarObject(resource, filename, event)
+    expect(response.status).toBe(201)
+
+    response = await webdav.calendarMultiGet(resource, filename)
+    expect(response.length)
+      .withContext(`Number of results from calendar-multiget`)
+      .toBe(1)
+
+    const calendarData = response[0].props.calendarData.replace(/\r\n/g, '\n')
+    const alarms = calendarData.match(/^BEGIN:VALARM$/gm) || []
+    const acknowledged = calendarData.match(/^ACKNOWLEDGED:20260211T121500Z$/gm) || []
+
+    expect(alarms.length)
+      .withContext(`Duplicated alarm is returned once and distinct alarm is preserved`)
+      .toBe(2)
+    expect(acknowledged.length)
+      .withContext(`Acknowledged alarm is preserved`)
+      .toBe(1)
+
+    const [objectProperties] = await webdav.propfindWebdav(resource + filename, ['getcontentlength'])
+    expect(Number(objectProperties.props.getcontentlength))
+      .withContext(`Persisted calendar object matches the returned normalized content`)
+      .toBe(Buffer.byteLength(response[0].props.calendarData, 'utf8'))
+  })
 })


### PR DESCRIPTION
## Problem

Malformed or re-uploaded calendar objects can contain repeated identical RRULE properties. SOGo currently stores and returns those duplicates, which can make Android/Etar import them as one concatenated recurrence rule and fail while parsing the event.

## Summary

- remove exact duplicate RRULE properties before returning CalDAV calendar data
- scrub exact duplicate RRULE properties before saving calendar components
- preserve different RRULE properties by comparing serialized rule content instead of iCalRecurrenceRule equality