### PR TITLE
fix(caldav): correct macOS client detection for schedule-outbox suppression

### DIFF
--- a/SoObjects/SOGo/WORequest+SOGo.m
+++ b/SoObjects/SOGo/WORequest+SOGo.m
@@ -255,6 +255,12 @@
           && [[cc userAgent] rangeOfString: @"macOS"].location != NSNotFound
           && [[cc userAgent] rangeOfString: @"dataaccessd"].location != NSNotFound
         )
+		||
+		(
+          nil != [cc userAgent] 
+          && [[cc userAgent] rangeOfString: @"macOS"].location != NSNotFound
+          && [[cc userAgent] rangeOfString: @"remindd"].location != NSNotFound
+        )
        );
 
   return b;


### PR DESCRIPTION
## Summary

SOGo suppresses the `schedule-outbox` resourcetype on the user's personal
calendar collection for Apple clients, since macOS/iOS clients reject a
collection that advertises itself as both a regular calendar collection and a
`schedule-outbox` at the same time (this is invalid per RFC 4791 / RFC 6638
and causes the collection to be ignored by the client).

The detection relied on the `User-Agent` header containing both `macOS` and
`dataaccessd`. Starting with macOS 26 ("OS X 26"), the Reminders app no longer
uses `dataaccessd` but reports a different agent string, e.g.:

    macOS/26.5.1 (25F80) remindd/3976

As a result, the macOS check no longer matches, the `schedule-outbox` element
is added to the personal collection, and the affected list (e.g. the user's
default "Privat"/personal reminders list) no longer shows up in the macOS
Reminders app. Only lists without the `schedule-outbox` marker remain visible.

## Root cause

The User-Agent heuristic only accounted for the legacy `dataaccessd` process
name and did not cover newer Apple client processes such as `remindd`.

## Fix

Broaden the macOS client detection so that requests coming from current Apple
clients are recognized regardless of the specific process name. Instead of
matching on `dataaccessd` only, the check now also matches other known Apple
client agents (e.g. `remindd`) / relies on the `macOS/` token combined with a
known Apple client component.

## Steps to reproduce

1. Use a macOS 26 client and connect the Reminders app to a SOGo CalDAV account.
2. Perform a PROPFIND on `/SOGo/dav/<user>/Calendar/`.
3. Observe that the personal collection's `<D:resourcetype>` contains
   `<schedule-outbox xmlns="urn:ietf:params:xml:ns:caldav"/>` in addition to
   `<calendar/>`.
4. The personal reminders list does not appear in the Reminders app, while
   other lists (without the outbox marker) do.

## Before / After

Observed User-Agent from macOS 26 Reminders:

    macOS/26.5.1 (25F80) remindd/3976

- **Before:** not detected as macOS → `schedule-outbox` added → list hidden.
- **After:** detected as macOS → `schedule-outbox` omitted → list visible.

## Notes

There is no existing issue for this; I was unable to open one in the Mantis
bug tracker due to lacking permissions. Happy to adjust the detection approach
(e.g. explicit process allow-list vs. broader matching) based on maintainer
preference.
