### PR TITLE
fix(mail): restore lost IMAP draft attachments when spool is empty

### DIFF
--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -1616,6 +1616,26 @@ static NSString    *userAgent      = nil;
 
   attrs = [self fetchAttachmentAttrs];
   count = [attrs count];
+
+  // If the spool directory has no attachment files but the draft exists
+  // in IMAP (has a valid IMAP4ID), it means the spool was cleaned up or
+  // this is a fresh editing session for a draft that was saved previously.
+  // In this case, restore the attachments from the IMAP message to spool
+  // so they are not silently dropped during MIME generation.
+  //
+  // We check IMAP4ID > -1 to ensure the draft was actually saved to IMAP
+  // before (not a brand-new unsaved draft).
+  if (count == 0 && IMAP4ID > -1)
+    {
+      SOGoMailObject *mail;
+
+      mail = [[[SOGoMailObject alloc] initWithImap4URL: [self imap4URL]
+                                           inContainer: [self container]] autorelease];
+      [self _fetchAttachmentsFromMail: mail onlyImages: NO];
+      attrs = [self fetchAttachmentAttrs];
+      count = [attrs count];
+    }
+
   size = 0;
 
   // We first check if we don't go over our message size limit


### PR DESCRIPTION
## Description

When reopening a previously saved draft for editing and then saving again, attachments are silently lost. The MIME message during `[SOGoDraftObject save]` is generated by reading attachment files from the **spool directory** via `bodyPartsForAllAttachments` → `fetchAttachmentAttrs`. If the spool is empty (server restart, cache cleanup, or a fresh editing session), the method returns zero files and the draft is saved to IMAP without any attachments.

## Root Cause

`bodyPartsForAllAttachments` only reads from the spool directory on disk. It has no fallback to the existing IMAP message, which still holds the original attachment data. When the spool and IMAP are out of sync, attachments are silently dropped during MIME generation.

## Fix

Added a guard at the beginning of `bodyPartsForAllAttachments` in `SoObjects/Mailer/SOGoDraftObject.m`:

- If `fetchAttachmentAttrs` returns **0 files** (`count == 0`), **AND** the draft has a valid `IMAP4ID > -1` (was previously saved to IMAP)...
- ...create a `SOGoMailObject` from the existing IMAP message, download all its attachments to the spool directory via the existing `_fetchAttachmentsFromMail:onlyImages:` method, then re-read the spool.

This ensures attachments are restored from IMAP before MIME generation, without affecting new drafts or drafts that already have files in spool.

## Impact

- **New drafts**: unaffected (`IMAP4ID == -1`)
- **Drafts with populated spool**: unaffected (`count > 0`)
- **Reopened drafts with cleaned/empty spool**: attachments are now correctly restored from IMAP

See #6046 for related draft attachment handling.