### PR TITLE
fix(mail): preserve spool attachments when SMTP send fails

### DIFF
--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -2406,16 +2406,17 @@ static NSString    *userAgent      = nil;
         }
     }
 
-  // Expunge Drafts mailbox if
-  //  - message was sent and saved to Sent mailbox if necessary;
+  // Delete local spool and expunge Drafts mailbox if
+  //  - message was sent successfully;
   //  - SOGoMailKeepDraftsAfterSend is not set;
-  //  - draft is successfully deleted;
   //  - drafts mailbox exists.
-  [self delete];
-  if (!error &&
-      ![dd mailKeepDraftsAfterSend] &&
-      [imap4 doesMailboxExistAtURL: [container imap4URL]])
-    [(SOGoDraftsFolder *) container expunge];
+  if (!error)
+    {
+      [self delete];
+      if (![dd mailKeepDraftsAfterSend] &&
+          [imap4 doesMailboxExistAtURL: [container imap4URL]])
+        [(SOGoDraftsFolder *) container expunge];
+    }
 
   [self cleanTmpFiles];
 


### PR DESCRIPTION
## Problem

When sending an email fails (e.g. invalid recipient), the editor stays open and the user can correct the address and re-send. However, all attachments are silently lost during the second send attempt.

## Root Cause

In `sendMailAndCopyToSent:` at `SoObjects/Mailer/SOGoDraftObject.m:2414`, `[self delete]` is called **unconditionally** after the SMTP send attempt. This removes the entire spool directory including:
- All attachment files
- `.info.plist` (which contains `IMAP4ID`)

On re-send, `bodyPartsForAllAttachments` finds the spool empty, MIME is generated without attachments, and the message is sent without them.

## Fix

Move `[self delete]` and the expunge operation inside `if (!error)`, so the spool is only cleaned up on successful send. This matches the existing pattern in the encrypted path (lines 2343-2346), where `cleanTmpFiles` is called and the method returns early on error.

## Affected file

`SoObjects/Mailer/SOGoDraftObject.m`