### PR TITLE
fix(mail): stop interpreting mail data in compiled part viewers

### DIFF
--- a/SoObjects/SOGo/NSString+Utilities.m
+++ b/SoObjects/SOGo/NSString+Utilities.m
@@ -942,12 +942,13 @@ static int cssEscapingCount;
   NSScanner *theScanner;
   NSError *error;
   NSUInteger numberOfMatches;
-  NSRegularExpression *regex;
+  NSRegularExpression *regex, *importRegex;
 
   text = nil;
   error = nil;
   result = [NSString stringWithString: self];
   regex = nil;
+  importRegex = nil;
   
   NS_DURING
   {
@@ -1056,9 +1057,9 @@ static int cssEscapingCount;
       result = [NSString stringWithString: newResult];
       
       // Remove @import css (in style tags)
-      regex = [NSRegularExpression regularExpressionWithPattern:@"(<[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*s[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*y[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*l[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*e.*)([\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*@[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*i[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*m[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*p[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*o[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*r[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t)(.*<[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*\\/[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*s[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*y[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*l[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*e[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*>)" 
+      importRegex = [NSRegularExpression regularExpressionWithPattern:@"(<[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*s[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*y[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*l[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*e.*)([\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*@[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*i[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*m[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*p[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*o[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*r[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t)(.*<[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*\\/[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*s[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*t[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*y[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*l[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*e[\\s\\u200B&#x09;&#x0A;&#x0D;\\\\0]*>)" 
                                   options: NSRegularExpressionCaseInsensitive error:&error];
-      newResult = [regex stringByReplacingMatchesInString:result options:0 range:NSMakeRange(0, [result length]) withTemplate:@"onrep***="];
+      newResult = [importRegex stringByReplacingMatchesInString:result options:0 range:NSMakeRange(0, [result length]) withTemplate:@"$1@im****$3"];
       result = [NSString stringWithString: newResult];
 
 
@@ -1075,8 +1076,8 @@ static int cssEscapingCount;
       }
 
       newResult = result;
-      while([regex numberOfMatchesInString:newResult options:0 range:NSMakeRange(0, [newResult length])] > 0) {
-        newResult = [regex stringByReplacingMatchesInString:newResult options:0 range:NSMakeRange(0, [newResult length]) withTemplate:@"$1@im****$3"];
+      while([importRegex numberOfMatchesInString:newResult options:0 range:NSMakeRange(0, [newResult length])] > 0) {
+        newResult = [importRegex stringByReplacingMatchesInString:newResult options:0 range:NSMakeRange(0, [newResult length]) withTemplate:@"$1@im****$3"];
       }
       result = [NSString stringWithString: newResult];
     }

--- a/Tests/Unit/TestNSString+Utilities.m
+++ b/Tests/Unit/TestNSString+Utilities.m
@@ -110,6 +110,8 @@
   testEquals([[NSString stringWithString:@"foobar <img onload=foo bar"] stringWithoutHTMLInjection: NO stripAngular: NO], @"foobar <img onl***=foo bar");
   testEquals([[NSString stringWithString:@"foobar <img onmouseover=foo bar"] stringWithoutHTMLInjection: NO stripAngular: NO], @"foobar <img onmouseo***=foo bar"); 
   testEquals([[NSString stringWithString:@"<!DOCTYPE html><html><head><style>@import url(https://foo.bar/malicious.css);.foo{background-color: red; @import url(https://bar.foo/malicious2.css);</style></head><body><table><tr><td>A</td><td>B</td><td>C</td></tr></table></body></html>"] stringWithoutHTMLInjection: NO stripAngular: NO], @"<!DOCTYPE html><html><head><style>@im**** url(https://foo.bar/malicious.css);.foo{background-color: red; @im**** url(https://bar.foo/malicious2.css);</style></head><body><table><tr><td>A</td><td>B</td><td>C</td></tr></table></body></html>");
+  // the @import cleanup must still run when angular interpolation is stripped as well
+  testEquals([[NSString stringWithString:@"<style>@import url(https://foo.bar/malicious.css);</style>"] stringWithoutHTMLInjection: NO stripAngular: YES], @"<style>@im**** url(https://foo.bar/malicious.css);</style>");
 }
 
 - (void) test_stringCleanInvalidHTMLTags

--- a/UI/MailPartViewers/UIxMailPartICalViewer.h
+++ b/UI/MailPartViewers/UIxMailPartICalViewer.h
@@ -46,6 +46,7 @@
 - (BOOL) isEndDateOnSameDay;
 - (BOOL) hasLocation;
 - (NSString *)location;
+- (NSString *) organizerHref;
 - (NSString *) userComment;
 - (NSString *) eventDescription;
 

--- a/UI/MailPartViewers/UIxMailPartICalViewer.h
+++ b/UI/MailPartViewers/UIxMailPartICalViewer.h
@@ -46,6 +46,8 @@
 - (BOOL) isEndDateOnSameDay;
 - (BOOL) hasLocation;
 - (NSString *)location;
+- (NSString *) userComment;
+- (NSString *) eventDescription;
 
 @end
 

--- a/UI/MailPartViewers/UIxMailPartICalViewer.m
+++ b/UI/MailPartViewers/UIxMailPartICalViewer.m
@@ -32,6 +32,7 @@
 
 #import <NGExtensions/NSCalendarDate+misc.h>
 #import <NGExtensions/NSObject+Logs.h>
+#import <NGExtensions/NSString+misc.h>
 
 #import <NGImap4/NGImap4EnvelopeAddress.h>
 
@@ -610,6 +611,16 @@
 
 - (NSString *) location {
   return [[self inEvent] location];
+}
+
+- (NSString *) userComment
+{
+  return [[[self inEvent] userComment] stringByEscapingHTMLString];
+}
+
+- (NSString *) eventDescription
+{
+  return [[[self authorativeEvent] comment] stringByEscapingHTMLString];
 }
 
 @end /* UIxMailPartICalViewer */

--- a/UI/MailPartViewers/UIxMailPartICalViewer.m
+++ b/UI/MailPartViewers/UIxMailPartICalViewer.m
@@ -418,6 +418,18 @@
   return YES;
 }
 
+- (NSString *) organizerHref
+{
+  NSString *address;
+
+  address = [[[self inEvent] organizer] rfc822Email];
+  if (![address length])
+    return nil;
+
+  return [[NSString stringWithFormat: @"mailto:%@", address]
+           stringByEscapingHTMLAttributeValue];
+}
+
 - (NSString *) organizerDisplayName
 {
   iCalPerson *organizer;

--- a/UI/MailPartViewers/UIxMailPartViewer.h
+++ b/UI/MailPartViewers/UIxMailPartViewer.h
@@ -86,6 +86,7 @@
 - (NSString *)preferredPathExtension;
 - (NSString *)filename;
 - (NSString *)filenameForDisplay;
+- (NSString *)filenameForTitle;
 - (NSFormatter *)sizeFormatter;
 
 /* caches */

--- a/UI/MailPartViewers/UIxMailPartViewer.m
+++ b/UI/MailPartViewers/UIxMailPartViewer.m
@@ -340,6 +340,14 @@
     : (id)@"untitled";
 }
 
+- (NSString *) filenameForTitle
+{
+  /* the generic attribute writer escapes & but not the quote, so a quote in the
+     filename would end the title attribute and start a new one */
+  return [[self filenameForDisplay] stringByReplacingOccurrencesOfString: @"\""
+                                                             withString: @""];
+}
+
 - (NSFormatter *) sizeFormatter
 {
   return [UIxMailSizeFormatter sharedMailSizeFormatter];

--- a/UI/Templates/MailPartViewers/UIxMailPartICalViewer.wox
+++ b/UI/Templates/MailPartViewers/UIxMailPartICalViewer.wox
@@ -137,7 +137,7 @@
 
             <p>
               <var:string label:value="Organizer" />
-              <a ng-non-bindable="" var:href="inEvent.organizer.email"
+              <a ng-non-bindable="" var:href="organizerHref"
 	         ><var:string value="organizerDisplayName" /></a>
               <var:string label:value="request_info" />
             </p>
@@ -147,7 +147,7 @@
           <var:if condition="isLoggedInUserAnAttendee" const:negate="YES">
             <p>
               <var:string label:value="Organizer" />
-              <a ng-non-bindable="" var:href="inEvent.organizer.email">
+              <a ng-non-bindable="" var:href="organizerHref">
                 <var:string value="organizerDisplayName" />
               </a>
               <var:string label:value="request_info_no_attendee" />

--- a/UI/Templates/MailPartViewers/UIxMailPartICalViewer.wox
+++ b/UI/Templates/MailPartViewers/UIxMailPartICalViewer.wox
@@ -17,7 +17,7 @@
           </div>
       </md-toolbar>
       <md-whiteframe class="md-whiteframe-z1" layout="row" layout-align="space-between center">
-        <pre><var:string value="flatContentAsString" /></pre>
+        <pre ng-non-bindable=""><var:string value="flatContentAsString" /></pre>
       </md-whiteframe>
     </div>
   </var:if> <!-- if condition="couldParseCalendar" const:negate="1" -->
@@ -137,7 +137,7 @@
 
             <p>
               <var:string label:value="Organizer" />
-              <a var:href="inEvent.organizer.email"
+              <a ng-non-bindable="" var:href="inEvent.organizer.email"
 	         ><var:string value="organizerDisplayName" /></a>
               <var:string label:value="request_info" />
             </p>
@@ -147,7 +147,7 @@
           <var:if condition="isLoggedInUserAnAttendee" const:negate="YES">
             <p>
               <var:string label:value="Organizer" />
-              <a var:href="inEvent.organizer.email">
+              <a ng-non-bindable="" var:href="inEvent.organizer.email">
                 <var:string value="organizerDisplayName" />
               </a>
               <var:string label:value="request_info_no_attendee" />
@@ -233,14 +233,14 @@
         </var:if>
 
         <!-- the user comment is used in replies -->
-        <var:if condition="inEvent.userComment.isNotEmpty">
+        <var:if condition="userComment.isNotEmpty">
           <div class="pseudo-input-container">
             <label class="pseudo-input-label">
               <var:string label:value="Comment"/>
             </label>
-            <div>
+            <div ng-non-bindable="">
               <md-content>
-                <var:string value="inEvent.userComment.stringByDetectingURLs" const:insertBR="1" const:escapeHTML="NO"/>
+                <var:string value="userComment.stringByDetectingURLs" const:insertBR="1" const:escapeHTML="NO"/>
               </md-content>
             </div>
           </div>
@@ -251,7 +251,7 @@
 	<var:if condition="hasOrganizer" const:value="true">
           <div class="pseudo-input-container">
             <label class="pseudo-input-label"><var:string label:value="Organizer"/></label>
-            <div>
+            <div ng-non-bindable="">
               <var:string value="organizerDisplayName"/>
             </div>
           </div>
@@ -268,7 +268,7 @@
         <var:if condition="hasLocation">
           <div class="pseudo-input-container">
             <label class="pseudo-input-label"><var:string label:value="Location"/></label>
-            <div>
+            <div ng-non-bindable="">
               <var:string value="location"/>
             </div>
           </div>
@@ -294,14 +294,14 @@
           </div>
         </md-list>
 
-        <var:if condition="authorativeEvent.comment.isNotEmpty">
+        <var:if condition="eventDescription.isNotEmpty">
           <div class="pseudo-input-container">
             <label class="pseudo-input-label">
               <var:string label:value="Description"/>
             </label>
             <div ng-non-bindable="">
               <md-content>
-                <var:string value="authorativeEvent.comment.stringByDetectingURLs" const:insertBR="1" const:escapeHTML="NO"/>
+                <var:string value="eventDescription.stringByDetectingURLs" const:insertBR="1" const:escapeHTML="NO"/>
               </md-content>
             </div>
           </div>

--- a/UI/Templates/MailPartViewers/UIxMailPartImageViewer.wox
+++ b/UI/Templates/MailPartViewers/UIxMailPartImageViewer.wox
@@ -10,7 +10,7 @@
     <img var:src="pathToAttachment"
          var:title="filenameForDisplay"><!-- image --></img>
     <md-card-content>
-      <p class="md-caption" var:title="filenameForDisplay">
+      <p class="md-caption" var:title="filenameForTitle">
         <var:string value="filenameForDisplay" />
       </p>
     </md-card-content>

--- a/UI/Templates/MailPartViewers/UIxMailPartLinkViewer.wox
+++ b/UI/Templates/MailPartViewers/UIxMailPartLinkViewer.wox
@@ -6,7 +6,7 @@
   xmlns:label="OGo:label">
   <md-card>
     <md-card-content>
-      <p class="md-caption sg-attachment-name" var:title="filenameForDisplay">
+      <p class="md-caption sg-attachment-name" var:title="filenameForTitle">
         <var:if condition="preferredPathExtension.length"><span class="sg-label-outline"><var:string value="preferredPathExtension"/></span></var:if>
         <var:string value="filenameForDisplay"/>
       </p>


### PR DESCRIPTION
### What

Data from a received message reaches the browser as markup inside the mail part viewers that are compiled by `sg-compile`:

* `UIxMailPartICalViewer.wox`: the user comment (`:243`), the location (`:272`), the organizer common name (`:141`, `:151`, `:255`) and the raw body shown when the calendar cannot be parsed (`:20`) are evaluated as AngularJS templates. The comment and the description are also emitted with `escapeHTML="NO"`.
* the same template: the organizer link took `inEvent.organizer.email` verbatim into `href`.
* `UIxMailPartImageViewer.wox` and `UIxMailPartLinkViewer.wox`: the attachment name paragraph took `filenameForDisplay` verbatim into `title`.

`47133fdf3` closed the description against interpolation. The rest was open.

### Why

`Message.service.js:463` sets `part.compile` for `UIxMailPartICalViewer`, `UIxMailPartImageViewer` and `UIxMailPartLinkViewer`, and `UIxMailViewTemplate.wox:433` renders those parts through `sg-compile`, so interpolation and injected handlers apply to the whole card. The HTML body part is rewritten server side by the sanitiser in `UIxMailPartHTMLViewer` before it is rendered, and its filter marks the result as trusted, so nothing sanitises it afterwards. The compiled parts get no server side pass at all.

`stringWithoutHTMLInjection` is a deny list (`onload=`, `onmouseover=`, `onrepeat=`, `onerror=`) and cannot carry these paths: it matches neither a handler written with a space before the `=` nor an entity encoded scheme such as `java&#115;cript:`.

### How

`ng-non-bindable` on the four remaining containers, the marker the description container at `:302` already uses. It sits on the leaf containers, not on `md-card-content`, so the buttons, the delegation autocomplete and the attendee chips keep being compiled.

The comment and the description are read through accessors that run `stringByEscapingHTMLString`, so URL detection and `insertBR` produce the only markup left. These are RFC 5545 text properties, not HTML.

The organizer href is built as `mailto:` plus the parsed address and escaped as an attribute value. The attachment title accessor drops a quote rather than escaping it, because the generic attribute writer escapes `&` there but not the quote; escaping the quote would show `&quot;` in the tooltip while a plain name such as `A&B.pdf` stays unchanged. The `img` title is left alone, attributes of that element are escaped already.

Second commit, `NSString+Utilities.m`: the trailing `while` loop reuses `regex`, which points at the angular brace pattern whenever `stripAngular` is `YES`. That pattern has two capture groups while the loop substitutes `$1@im****$3`, so `NSRegularExpression` raises and `NS_HANDLER` swallows it. The `@import` pattern gets its own variable. The replacement above it used the template of the preceding block, which dropped the whole style element instead of masking in place.

Deliberately unchanged: the deny list itself, and the sanitising of `authorativeEvent`'s description.

### Testing

`make` in `SoObjects/SOGo`, `UI/MailPartViewers` and `UI/Templates` is clean.

`Tests/Unit/sogo-tests`: 40 tests, 3 failures before, 2 after. `test_stringWithoutHTMLInjection` passes again and gained a case with `stripAngular: YES`. The remaining `test_NGInternetSocketAddressFromString` and `test_generateDataForHeaderFieldNamed_value_` fail on the untouched base as well.

Live on 5.12.10 built from this branch, 46 crafted mails driven in Chrome, one sink per mail, each opened in the message view with the events the payloads hook dispatched afterwards. Before the change an expression is evaluated in the comment, the location, the organizer CN and in an unparseable body; an image with a handler attribute runs in the comment and the description; a quoted organizer value gives the anchor a live handler; an entity encoded scheme reaches the href as a `javascript:` protocol; a quote in an RFC 2231 filename gives the attachment name a live handler. After the change none of the 46 shows an evaluated expression, a `javascript:` href, an inline handler attribute or a fired payload. Reverting one hunk brings the matching probes back, which is how the detector was checked.

Unchanged behaviour: the invitation buttons, the attendee chips and the avatar still render, a bare URL in a comment or a description still becomes a link, non-ASCII text still displays, and a plain attachment name such as `Report A&B (final) 100%.png` is unchanged in the tooltip.

Found during a security review at [turingpoint](https://www.turingpoint.de).