### PR TITLE
fix(mail): don't drop explicitly attached S/MIME signature files

### DIFF
--- a/SoObjects/Mailer/SOGoDraftObject.m
+++ b/SoObjects/Mailer/SOGoDraftObject.m
@@ -1631,8 +1631,11 @@ static NSString    *userAgent      = nil;
   for (i = 0; i < count; i++)
     {
       contentType = [[[attrs objectAtIndex: i] objectForKey: @"part"] headerForKey: @"content-type"];
-      if ([contentType isEqualToString: @"application/pkcs7-signature"])
-        // Skip SMIME signature as it will be resigned later
+      if ([self sign] && [contentType isEqualToString: @"application/pkcs7-signature"])
+        // Skip a stale SMIME signature part only when this message will actually
+        // be re-signed on send; a detached signature file the user explicitly
+        // attached (sign not requested for this message) must be preserved as
+        // a normal attachment instead of being silently dropped.
         continue;
       bodyPart = [self bodyPartForAttachmentWithName: [[attrs objectAtIndex: i] objectForKey: @"filename"]];
       [bodyParts addObject: bodyPart];


### PR DESCRIPTION
## Problem

When a user attaches a detached S/MIME signature file to an outgoing message via the web UI (e.g. `document.pdf` together with `document.pdf.p7s`, a very common pattern for signed government/tax e-documents), the attachment is silently dropped from the message — with no error shown anywhere in the UI.

- The upload request to `/save` returns **HTTP 200**.
- The response body's `lastAttachmentAttrs` comes back as an **empty array** instead of the real attachment metadata.
- A follow-up fetch of the saved draft confirms the file is genuinely **not present** in the message — it isn't a display bug, the part was never written into the final MIME structure.

## Root cause

`SOGoDraftObject.m`, `bodyPartsForAllAttachments`:

```objc
contentType = [[[attrs objectAtIndex: i] objectForKey: @"part"] headerForKey: @"content-type"];
if ([contentType isEqualToString: @"application/pkcs7-signature"])
  // Skip SMIME signature as it will be resigned later
  continue;
```

This unconditionally skips **any** attachment whose Content-Type is exactly `application/pkcs7-signature`, regardless of whether the *current* outgoing message is being signed at all. The intent (per the comment) is clearly to avoid re-attaching a *stale* signature part inherited from, say, forwarding an already-signed message — SOGo regenerates that signature itself when `sign` is requested for the new message.

But the check has no relation to whether re-signing is actually going to happen. If the user has **not** requested signing for the current message (`sign == NO`) and simply attaches an independent `.p7s` file as a payload (not connected to this message's own signing), it gets matched by the same unconditional string comparison and is dropped anyway — even though nothing will regenerate it.

The file itself does get saved to the draft's attachment spool fine (`saveAttachment:withMetadata:` in `UIxMailEditor.m` succeeds, which is why the initial `/save` call returns 200) — it's only excluded later, when `bodyPartsForAllAttachments` assembles the actual MIME parts for the saved/sent message.

## Steps to reproduce

1. Open a new compose window. Do **not** enable "Sign this message".
2. Attach any file whose extension causes the browser to set `Content-Type: application/pkcs7-signature` on upload — a plain `.p7s` file (e.g. `document.pdf.p7s`) reliably does this in current Chrome/Firefox on Windows.
3. Save the draft (or send).
4. Observe: `POST .../save` returns 200 with `"lastAttachmentAttrs":[]`. Reopen/reload the draft — the attachment is gone, with no error ever shown to the user.

## Fix

Only skip the `application/pkcs7-signature` part when the message is actually going to be (re)signed:

```objc
if ([self sign] && [contentType isEqualToString: @"application/pkcs7-signature"])
  // Skip a stale SMIME signature part only when this message will actually
  // be re-signed on send; a detached signature file the user explicitly
  // attached (sign not requested for this message) must be preserved as
  // a normal attachment instead of being silently dropped.
  continue;
```

`sign` is already available on `SOGoDraftObject` (`[self sign]` / `setSign:`), so this is a minimal, self-contained change with no new state.

## Testing

Built and deployed on a live mailcow-dockerized instance (SOGo 5.12.10 built from source with this patch applied) and confirmed:

- Attaching an independent `.p7s` file to an unsigned message is now preserved in the saved/sent draft (previously silently dropped).
- Existing behavior for an actually-signed message (`sign == YES`) is unchanged — the stale signature part is still skipped and correctly regenerated on send.
